### PR TITLE
Use user id class in ACLs

### DIFF
--- a/lib/SampleService/core/acls.py
+++ b/lib/SampleService/core/acls.py
@@ -8,6 +8,7 @@ from typing import Sequence
 from SampleService.core.arg_checkers import not_falsy as _not_falsy
 from SampleService.core.arg_checkers import not_falsy_in_iterable as _not_falsy_in_iterable
 from SampleService.core.errors import IllegalParameterError as _IllegalParameterError
+from SampleService.core.user import UserID
 
 
 class SampleAccessType(IntEnum):
@@ -42,9 +43,9 @@ class SampleACLOwnerless:
 
     def __init__(
             self,
-            admin: Sequence[str] = None,
-            write: Sequence[str] = None,
-            read: Sequence[str] = None):
+            admin: Sequence[UserID] = None,
+            write: Sequence[UserID] = None,
+            read: Sequence[UserID] = None):
         '''
         Create the ACLs.
 
@@ -90,10 +91,10 @@ class SampleACL(SampleACLOwnerless):
 
     def __init__(
             self,
-            owner: str,
-            admin: Sequence[str] = None,
-            write: Sequence[str] = None,
-            read: Sequence[str] = None):
+            owner: UserID,
+            admin: Sequence[UserID] = None,
+            write: Sequence[UserID] = None,
+            read: Sequence[UserID] = None):
         '''
         Create the ACLs.
 

--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -726,7 +726,11 @@ class ArangoSampleStorage:
         # return no class for now, might need later
         doc = _cast(dict, self._get_sample_doc(id_))
         acls = doc[_FLD_ACLS]
-        return SampleACL(acls[_FLD_OWNER], acls[_FLD_ADMIN], acls[_FLD_WRITE], acls[_FLD_READ])
+        return SampleACL(
+            _UserID(acls[_FLD_OWNER]),
+            [_UserID(u) for u in acls[_FLD_ADMIN]],
+            [_UserID(u) for u in acls[_FLD_WRITE]],
+            [_UserID(u) for u in acls[_FLD_READ]])
 
     def replace_sample_acls(self, id_: UUID, acls: SampleACL):
         '''
@@ -757,10 +761,10 @@ class ArangoSampleStorage:
             '''
         bind_vars = {'@col': self._col_sample.name,
                      'id': str(id_),
-                     'owner': acls.owner,
-                     'acls': {_FLD_ADMIN: acls.admin,
-                              _FLD_WRITE: acls.write,
-                              _FLD_READ: acls.read
+                     'owner': acls.owner.id,
+                     'acls': {_FLD_ADMIN: [u.id for u in acls.admin],
+                              _FLD_WRITE: [u.id for u in acls.write],
+                              _FLD_READ: [u.id for u in acls.read]
                               }
                      }
         try:

--- a/lib/SampleService/core/user.py
+++ b/lib/SampleService/core/user.py
@@ -3,9 +3,6 @@
 from SampleService.core.arg_checkers import check_string as _check_string
 
 
-# TODO CODE When you see a bare username, replace with this class
-
-
 class UserID:
     '''
     A users's unique name / identifier.

--- a/lib/SampleService/core/user_lookup.py
+++ b/lib/SampleService/core/user_lookup.py
@@ -10,6 +10,7 @@ from typing import List, Sequence, Tuple
 from SampleService.core.arg_checkers import not_falsy as _not_falsy
 from SampleService.core.arg_checkers import not_falsy_in_iterable as _no_falsy_in_iterable
 from SampleService.core.acls import AdminPermission
+from SampleService.core.user import UserID
 
 
 class KBaseUserLookup:
@@ -74,7 +75,7 @@ class KBaseUserLookup:
             # worry about it later.
             raise IOError('Error from KBase auth server: ' + j['error']['message'])
 
-    def are_valid_users(self, usernames: Sequence[str]) -> List[str]:
+    def are_valid_users(self, usernames: Sequence[UserID]) -> List[UserID]:
         '''
         Check whether users exist in the authentication service.
 
@@ -90,12 +91,12 @@ class KBaseUserLookup:
             return []
         _no_falsy_in_iterable(usernames, 'usernames')
 
-        r = requests.get(self._user_url + ','.join(usernames),
+        r = requests.get(self._user_url + ','.join([u.id for u in usernames]),
                          headers={'Authorization': self._token})
         self._check_error(r)
         good_users = r.json()
         # TODO ACL cache
-        return [u for u in usernames if u not in good_users]
+        return [u for u in usernames if u.id not in good_users]
 
     def is_admin(self, token: str) -> Tuple[AdminPermission, str]:
         '''

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -19,6 +19,7 @@ from SampleService.core.user_lookup import KBaseUserLookup, AdminPermission
 from SampleService.core.user_lookup import InvalidTokenError, InvalidUserError
 from SampleService.core.workspace import WS, WorkspaceAccessType, UPA
 from SampleService.core.errors import UnauthorizedError, NoSuchUserError
+from SampleService.core.user import UserID
 
 from installed_clients.WorkspaceClient import Workspace as Workspace
 
@@ -1389,19 +1390,20 @@ def _user_lookup_build_fail(url, token, expected):
 def test_user_lookup(sample_port, auth):
     ul = KBaseUserLookup(f'http://localhost:{auth.port}/testmode', TOKEN1)
     assert ul.are_valid_users([]) == []
-    assert ul.are_valid_users([USER1, USER2, USER3]) == []
+    assert ul.are_valid_users([UserID(USER1), UserID(USER2), UserID(USER3)]) == []
 
 
 def test_user_lookup_bad_users(sample_port, auth):
     ul = KBaseUserLookup(f'http://localhost:{auth.port}/testmode/', TOKEN1)
     assert ul.are_valid_users(
-        ['nouserhere', USER1, USER2, 'whooptydoo', USER3]) == ['nouserhere', 'whooptydoo']
+        [UserID('nouserhere'), UserID(USER1), UserID(USER2), UserID('whooptydoo'),
+         UserID(USER3)]) == [UserID('nouserhere'), UserID('whooptydoo')]
 
 
 def test_user_lookup_fail_bad_args(sample_port, auth):
     ul = KBaseUserLookup(f'http://localhost:{auth.port}/testmode/', TOKEN1)
     _user_lookup_fail(ul, None, ValueError('usernames cannot be None'))
-    _user_lookup_fail(ul, ['foo', 'bar', ''], ValueError(
+    _user_lookup_fail(ul, [UserID('foo'), UserID('bar'), None], ValueError(
         'Index 2 of iterable usernames cannot be a value that evaluates to false'))
 
 
@@ -1409,7 +1411,7 @@ def test_user_lookup_fail_bad_username(sample_port, auth):
     ul = KBaseUserLookup(f'http://localhost:{auth.port}/testmode/', TOKEN1)
     # maybe possibly this error should be shortened
     # definitely clear the user name is illegal though, there's no question about that
-    _user_lookup_fail(ul, ['1'], InvalidUserError(
+    _user_lookup_fail(ul, [UserID('1')], InvalidUserError(
         'The KBase auth server is being very assertive about one of the usernames being ' +
         'illegal: 30010 Illegal user name: Illegal user name [1]: 30010 Illegal user name: ' +
         'Username must start with a letter'))

--- a/test/core/acls_test.py
+++ b/test/core/acls_test.py
@@ -3,6 +3,11 @@ from pytest import raises
 from SampleService.core.acls import SampleACL, SampleACLOwnerless
 from core.test_utils import assert_exception_correct
 from SampleService.core.errors import IllegalParameterError
+from SampleService.core.user import UserID
+
+
+def u(user):
+    return UserID(user)
 
 
 def test_build_ownerless():
@@ -13,27 +18,32 @@ def test_build_ownerless():
 
     # test duplicates are removed and order maintained
     a = SampleACLOwnerless(
-        ['baz', 'bat', 'baz'], read=['wheee', 'wheee'], write=['wugga', 'a', 'b', 'a'])
-    assert a.admin == ('baz', 'bat')
-    assert a.write == ('wugga', 'a', 'b')
-    assert a.read == ('wheee',)
+        [u('baz'), u('bat'), u('baz')],
+        read=[u('wheee'), u('wheee')],
+        write=[u('wugga'), u('a'), u('b'), u('a')])
+    assert a.admin == (u('baz'), u('bat'))
+    assert a.write == (u('wugga'), u('a'), u('b'))
+    assert a.read == (u('wheee'),)
 
 
 def test_build_fail_ownerless():
-    _build_fail_ownerless(['a', ''], None, None, ValueError(
+    _build_fail_ownerless([u('a'), None], None, None, ValueError(
         'Index 1 of iterable admin cannot be a value that evaluates to false'))
-    _build_fail_ownerless(None, ['', ''], None, ValueError(
+    _build_fail_ownerless(None, [None, None], None, ValueError(
         'Index 0 of iterable write cannot be a value that evaluates to false'))
-    _build_fail_ownerless(None, None, ['a', 'b', ''], ValueError(
+    _build_fail_ownerless(None, None, [u('a'), u('b'), None], ValueError(
         'Index 2 of iterable read cannot be a value that evaluates to false'))
 
     # test that you cannot have a user in 2 acls
-    _build_fail_ownerless(['a', 'z'], ['a', 'c'], ['w', 'b'], IllegalParameterError(
-        'User a appears in two ACLs'))
-    _build_fail_ownerless(['a', 'z'], ['b', 'c'], ['w', 'a'], IllegalParameterError(
-        'User a appears in two ACLs'))
-    _build_fail_ownerless(['x', 'z'], ['b', 'c', 'w'], ['w', 'a'], IllegalParameterError(
-        'User w appears in two ACLs'))
+    _build_fail_ownerless(
+        [u('a'), u('z')], [u('a'), u('c')], [u('w'), u('b')],
+        IllegalParameterError('User a appears in two ACLs'))
+    _build_fail_ownerless(
+        [u('a'), u('z')], [u('b'), u('c')], [u('w'), u('a')],
+        IllegalParameterError('User a appears in two ACLs'))
+    _build_fail_ownerless(
+        [u('x'), u('z')], [u('b'), u('c'), u('w')], [u('w'), u('a')],
+        IllegalParameterError('User w appears in two ACLs'))
 
 
 def _build_fail_ownerless(admin, write, read, expected):
@@ -43,17 +53,17 @@ def _build_fail_ownerless(admin, write, read, expected):
 
 
 def test_eq_ownerless():
-    assert SampleACLOwnerless(['bar']) == SampleACLOwnerless(['bar'])
-    assert SampleACLOwnerless(['bar']) != SampleACLOwnerless(['baz'])
+    assert SampleACLOwnerless([u('bar')]) == SampleACLOwnerless([u('bar')])
+    assert SampleACLOwnerless([u('bar')]) != SampleACLOwnerless([u('baz')])
 
-    assert SampleACLOwnerless(write=['bar']) == SampleACLOwnerless(write=['bar'])
-    assert SampleACLOwnerless(write=['bar']) != SampleACLOwnerless(write=['baz'])
+    assert SampleACLOwnerless(write=[u('bar')]) == SampleACLOwnerless(write=[u('bar')])
+    assert SampleACLOwnerless(write=[u('bar')]) != SampleACLOwnerless(write=[u('baz')])
 
-    assert SampleACLOwnerless(read=['bar']) == SampleACLOwnerless(read=['bar'])
-    assert SampleACLOwnerless(read=['bar']) != SampleACLOwnerless(read=['baz'])
+    assert SampleACLOwnerless(read=[u('bar')]) == SampleACLOwnerless(read=[u('bar')])
+    assert SampleACLOwnerless(read=[u('bar')]) != SampleACLOwnerless(read=[u('baz')])
 
-    assert SampleACLOwnerless('foo') != 1
-    assert 'foo' != SampleACLOwnerless('foo')
+    assert SampleACLOwnerless([u('foo')]) != 1
+    assert u('foo') != SampleACLOwnerless([u('foo')])
 
 
 def test_hash_ownerless():
@@ -61,56 +71,65 @@ def test_hash_ownerless():
     # tests can't be written that directly test the hash value. See
     # https://docs.python.org/3/reference/datamodel.html#object.__hash__
 
-    assert hash(SampleACLOwnerless(['bar'])) == hash(SampleACLOwnerless(['bar']))
-    assert hash(SampleACLOwnerless(['bar'])) != hash(SampleACLOwnerless(['baz']))
+    assert hash(SampleACLOwnerless([u('bar')])) == hash(SampleACLOwnerless([u('bar')]))
+    assert hash(SampleACLOwnerless([u('bar')])) != hash(SampleACLOwnerless([u('baz')]))
 
-    assert hash(SampleACLOwnerless(write=['bar'])) == hash(SampleACLOwnerless(write=['bar']))
-    assert hash(SampleACLOwnerless(write=['bar'])) != hash(SampleACLOwnerless(write=['baz']))
+    assert hash(SampleACLOwnerless(write=[u('bar')])) == hash(SampleACLOwnerless(write=[u('bar')]))
+    assert hash(SampleACLOwnerless(write=[u('bar')])) != hash(SampleACLOwnerless(write=[u('baz')]))
 
-    assert hash(SampleACLOwnerless(read=['bar'])) == hash(SampleACLOwnerless(read=['bar']))
-    assert hash(SampleACLOwnerless(read=['bar'])) != hash(SampleACLOwnerless(read=['baz']))
+    assert hash(SampleACLOwnerless(read=[u('bar')])) == hash(SampleACLOwnerless(read=[u('bar')]))
+    assert hash(SampleACLOwnerless(read=[u('bar')])) != hash(SampleACLOwnerless(read=[u('baz')]))
 
 
 def test_build():
-    a = SampleACL('foo')
-    assert a.owner == 'foo'
+    a = SampleACL(u('foo'))
+    assert a.owner == u('foo')
     assert a.admin == ()
     assert a.write == ()
     assert a.read == ()
 
     a = SampleACL(
-        'foo', ['baz', 'bat', 'baz'], read=['wheee', 'wheee'], write=['wugga', 'a', 'b', 'wugga'])
-    assert a.owner == 'foo'
-    assert a.admin == ('baz', 'bat')
-    assert a.write == ('wugga', 'a', 'b')
-    assert a.read == ('wheee',)
+        u('foo'),
+        [u('baz'), u('bat'), u('baz')],
+        read=[u('wheee'), u('wheee')],
+        write=[u('wugga'), u('a'), u('b'), u('wugga')])
+    assert a.owner == u('foo')
+    assert a.admin == (u('baz'), u('bat'))
+    assert a.write == (u('wugga'), u('a'), u('b'))
+    assert a.read == (u('wheee'),)
 
 
 def test_build_fail():
-    _build_fail('', None, None, None, ValueError(
+    _build_fail(None, None, None, None, ValueError(
         'owner cannot be a value that evaluates to false'))
-    _build_fail('foo', ['a', ''], None, None, ValueError(
+    _build_fail(u('foo'), [u('a'), None], None, None, ValueError(
         'Index 1 of iterable admin cannot be a value that evaluates to false'))
-    _build_fail('foo', None, ['', ''], None, ValueError(
+    _build_fail(u('foo'), None, [None, None], None, ValueError(
         'Index 0 of iterable write cannot be a value that evaluates to false'))
-    _build_fail('foo', None, None, ['a', 'b', ''], ValueError(
+    _build_fail(u('foo'), None, None, [u('a'), u('b'), None], ValueError(
         'Index 2 of iterable read cannot be a value that evaluates to false'))
 
     # test that you cannot have an owner in another ACL
-    _build_fail('foo', ['c', 'd', 'foo'], None, ['a', 'b', 'x'], IllegalParameterError(
-        'The owner cannot be in any other ACL'))
-    _build_fail('foo', None, ['a', 'b', 'foo'], ['x'], IllegalParameterError(
-        'The owner cannot be in any other ACL'))
-    _build_fail('foo', ['y'], None, ['a', 'b', 'foo'], IllegalParameterError(
-        'The owner cannot be in any other ACL'))
+    _build_fail(
+        u('foo'), [u('c'), u('d'), u('foo')], None, [u('a'), u('b'), u('x')],
+        IllegalParameterError('The owner cannot be in any other ACL'))
+    _build_fail(
+        u('foo'), None, [u('a'), u('b'), u('foo')], [u('x')],
+        IllegalParameterError('The owner cannot be in any other ACL'))
+    _build_fail(
+        u('foo'), [u('y')], None, [u('a'), u('b'), u('foo')],
+        IllegalParameterError('The owner cannot be in any other ACL'))
 
     # test that you cannot have a user in 2 acls
-    _build_fail('foo', ['a', 'z'], ['a', 'c'], ['w', 'b'], IllegalParameterError(
-        'User a appears in two ACLs'))
-    _build_fail('foo', ['a', 'z'], ['b', 'c'], ['w', 'a'], IllegalParameterError(
-        'User a appears in two ACLs'))
-    _build_fail('foo', ['x', 'z'], ['b', 'c', 'w'], ['w', 'a'], IllegalParameterError(
-        'User w appears in two ACLs'))
+    _build_fail(
+        u('foo'), [u('a'), u('z')], [u('a'), u('c')], [u('w'), u('b')],
+        IllegalParameterError('User a appears in two ACLs'))
+    _build_fail(
+        u('foo'), [u('a'), u('z')], [u('b'), u('c')], [u('w'), u('a')],
+        IllegalParameterError('User a appears in two ACLs'))
+    _build_fail(
+        u('foo'), [u('x'), u('z')], [u('b'), u('c'), u('w')], [u('w'), u('a')],
+        IllegalParameterError('User w appears in two ACLs'))
 
 
 def _build_fail(owner, admin, write, read, expected):
@@ -120,20 +139,20 @@ def _build_fail(owner, admin, write, read, expected):
 
 
 def test_eq():
-    assert SampleACL('foo') == SampleACL('foo')
-    assert SampleACL('foo') != SampleACL('bar')
+    assert SampleACL(u('foo')) == SampleACL(u('foo'))
+    assert SampleACL(u('foo')) != SampleACL(u('bar'))
 
-    assert SampleACL('foo', ['bar']) == SampleACL('foo', ['bar'])
-    assert SampleACL('foo', ['bar']) != SampleACL('foo', ['baz'])
+    assert SampleACL(u('foo'), [u('bar')]) == SampleACL(u('foo'), [u('bar')])
+    assert SampleACL(u('foo'), [u('bar')]) != SampleACL(u('foo'), [u('baz')])
 
-    assert SampleACL('foo', write=['bar']) == SampleACL('foo', write=['bar'])
-    assert SampleACL('foo', write=['bar']) != SampleACL('foo', write=['baz'])
+    assert SampleACL(u('foo'), write=[u('bar')]) == SampleACL(u('foo'), write=[u('bar')])
+    assert SampleACL(u('foo'), write=[u('bar')]) != SampleACL(u('foo'), write=[u('baz')])
 
-    assert SampleACL('foo', read=['bar']) == SampleACL('foo', read=['bar'])
-    assert SampleACL('foo', read=['bar']) != SampleACL('foo', read=['baz'])
+    assert SampleACL(u('foo'), read=[u('bar')]) == SampleACL(u('foo'), read=[u('bar')])
+    assert SampleACL(u('foo'), read=[u('bar')]) != SampleACL(u('foo'), read=[u('baz')])
 
-    assert SampleACL('foo') != 1
-    assert 'foo' != SampleACL('foo')
+    assert SampleACL(u('foo')) != 1
+    assert u('foo') != SampleACL(u('foo'))
 
 
 def test_hash():
@@ -141,15 +160,17 @@ def test_hash():
     # tests can't be written that directly test the hash value. See
     # https://docs.python.org/3/reference/datamodel.html#object.__hash__
 
-    assert hash(SampleACL('foo')) == hash(SampleACL('foo'))
-    assert hash(SampleACL('bar')) == hash(SampleACL('bar'))
-    assert hash(SampleACL('foo')) != hash(SampleACL('bar'))
+    assert hash(SampleACL(u('foo'))) == hash(SampleACL(u('foo')))
+    assert hash(SampleACL(u('bar'))) == hash(SampleACL(u('bar')))
+    assert hash(SampleACL(u('foo'))) != hash(SampleACL(u('bar')))
 
-    assert hash(SampleACL('foo', ['bar'])) == hash(SampleACL('foo', ['bar']))
-    assert hash(SampleACL('foo', ['bar'])) != hash(SampleACL('foo', ['baz']))
+    assert hash(SampleACL(u('foo'), [u('bar')])) == hash(SampleACL(u('foo'), [u('bar')]))
+    assert hash(SampleACL(u('foo'), [u('bar')])) != hash(SampleACL(u('foo'), [u('baz')]))
 
-    assert hash(SampleACL('foo', write=['bar'])) == hash(SampleACL('foo', write=['bar']))
-    assert hash(SampleACL('foo', write=['bar'])) != hash(SampleACL('foo', write=['baz']))
+    assert hash(SampleACL(u('foo'), write=[u('bar')])) == hash(
+        SampleACL(u('foo'), write=[u('bar')]))
+    assert hash(SampleACL(u('foo'), write=[u('bar')])) != hash(
+        SampleACL(u('foo'), write=[u('baz')]))
 
-    assert hash(SampleACL('foo', read=['bar'])) == hash(SampleACL('foo', read=['bar']))
-    assert hash(SampleACL('foo', read=['bar'])) != hash(SampleACL('foo', read=['baz']))
+    assert hash(SampleACL(u('foo'), read=[u('bar')])) == hash(SampleACL(u('foo'), read=[u('bar')]))
+    assert hash(SampleACL(u('foo'), read=[u('bar')])) != hash(SampleACL(u('foo'), read=[u('baz')]))

--- a/test/core/api_translation_test.py
+++ b/test/core/api_translation_test.py
@@ -364,7 +364,7 @@ def test_sample_to_dict_fail():
 
 
 def test_acls_to_dict_minimal():
-    assert acls_to_dict(SampleACL('user')) == {
+    assert acls_to_dict(SampleACL(UserID('user'))) == {
         'owner': 'user',
         'admin': (),
         'write': (),
@@ -375,10 +375,10 @@ def test_acls_to_dict_minimal():
 def test_acls_to_dict_maximal():
     assert acls_to_dict(
         SampleACL(
-            'user',
-            ['foo', 'bar'],
-            ['baz'],
-            ['hello', "I'm", 'a', 'robot'])) == {
+            UserID('user'),
+            [UserID('foo'), UserID('bar')],
+            [UserID('baz')],
+            [UserID('hello'), UserID("I'm"), UserID('a'), UserID('robot')])) == {
         'owner': 'user',
         'admin': ('foo', 'bar'),
         'write': ('baz',),
@@ -397,11 +397,12 @@ def test_acls_from_dict():
     assert acls_from_dict({'acls': {}}) == SampleACLOwnerless()
     assert acls_from_dict({'acls': {
         'read': [],
-        'admin': ['whee', 'whoo']}}) == SampleACLOwnerless(['whee', 'whoo'])
+        'admin': ['whee', 'whoo']}}) == SampleACLOwnerless([UserID('whee'), UserID('whoo')])
     assert acls_from_dict({'acls': {
         'read': ['a', 'b'],
         'write': ['x'],
-        'admin': ['whee', 'whoo']}}) == SampleACLOwnerless(['whee', 'whoo'], ['x'], ['a', 'b'])
+        'admin': ['whee', 'whoo']}}) == SampleACLOwnerless(
+            [UserID('whee'), UserID('whoo')], [UserID('x')], [UserID('a'), UserID('b')])
 
 
 def test_acls_from_dict_fail_bad_args():

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -18,6 +18,10 @@ from SampleService.core import user_lookup
 from core.test_utils import assert_exception_correct
 
 
+def u(user):
+    return UserID(user)
+
+
 def nw():
     return datetime.datetime.fromtimestamp(6, tz=datetime.timezone.utc)
 
@@ -114,7 +118,10 @@ def _save_sample_version_per_user(user: UserID, name, prior_version):
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.')])
 
     storage.save_sample_version.return_value = 3
 
@@ -222,7 +229,10 @@ def _save_sample_fail_unauthorized(user: UserID):
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     with raises(Exception) as got:
         samples.save_sample(
@@ -259,11 +269,14 @@ def _get_sample(user, version, as_admin):
         storage, lu, meta, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     storage.get_sample.return_value = SavedSample(
         UUID('1234567890abcdef1234567890abcdea'),
-        'anotheruser',
+        UserID('anotheruser'),
         [SampleNode('foo')],
         datetime.datetime.fromtimestamp(42, tz=datetime.timezone.utc),
         'bar',
@@ -272,7 +285,7 @@ def _get_sample(user, version, as_admin):
     assert samples.get_sample(
         UUID('1234567890abcdef1234567890abcdea'), user, version, as_admin) == SavedSample(
             UUID('1234567890abcdef1234567890abcdea'),
-            'anotheruser',
+            UserID('anotheruser'),
             [SampleNode('foo')],
             datetime.datetime.fromtimestamp(42, tz=datetime.timezone.utc),
             'bar',
@@ -310,7 +323,10 @@ def test_get_sample_fail_unauthorized():
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     _get_sample_fail(
         samples, UUID('1234567890abcdef1234567890abcdef'), UserID('y'), 3,
@@ -343,10 +359,16 @@ def _get_sample_acls(user, as_admin):
     id_ = UUID('1234567890abcdef1234567890abcde0')
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     assert samples.get_sample_acls(id_, user, as_admin) == SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     assert storage.get_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),), {})]
@@ -374,7 +396,10 @@ def test_get_sample_acls_fail_unauthorized():
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     _get_sample_acls_fail(
         samples, UUID('1234567890abcdef1234567890abcdea'), UserID('y'),
@@ -407,20 +432,24 @@ def _replace_sample_acls(user: UserID, as_admin):
     lu.are_valid_users.return_value = []
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser', 'y'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser'), u('y')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
     samples.replace_sample_acls(id_, user, SampleACL(
-        'someuser', ['x', 'y'], ['z', 'a'], ['b', 'c']),
+        u('someuser'), [u('x'), u('y')], [u('z'), u('a')], [u('b'), u('c')]),
         as_admin=as_admin)
 
-    assert lu.are_valid_users.call_args_list == [((['x', 'y', 'z', 'a', 'b', 'c'],), {})]
+    assert lu.are_valid_users.call_args_list == [
+        (([u(x) for x in ['x', 'y', 'z', 'a', 'b', 'c']],), {})]
 
     assert storage.get_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),), {})]
 
     assert storage.replace_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),
-          SampleACL('someuser', ['x', 'y'], ['z', 'a'], ['b', 'c'])), {})]
+          SampleACL(u('someuser'), [u('x'), u('y')], [u('z'), u('a')], [u('b'), u('c')])), {})]
 
 
 def test_replace_sample_acls_with_owner_change():
@@ -435,16 +464,19 @@ def test_replace_sample_acls_with_owner_change():
 
     storage.get_sample_acls.side_effect = [
         SampleACL(
-            'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x']),
+            u('someuser'),
+            [u('otheruser')],
+            [u('anotheruser'), u('ur mum')],
+            [u('Fungus J. Pustule Jr.'), u('x')]),
         SampleACL(
-            'someuser2', ['otheruser', 'y'],)
+            u('someuser2'), [u('otheruser'), u('y')],)
         ]
 
     storage.replace_sample_acls.side_effect = [OwnerChangedError, None]
 
-    samples.replace_sample_acls(id_, UserID('otheruser'), SampleACL('someuser', ['a']))
+    samples.replace_sample_acls(id_, UserID('otheruser'), SampleACL(u('someuser'), [u('a')]))
 
-    assert lu.are_valid_users.call_args_list == [((['a'],), {})]
+    assert lu.are_valid_users.call_args_list == [(([u('a')],), {})]
 
     assert storage.get_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),), {}),
@@ -452,8 +484,8 @@ def test_replace_sample_acls_with_owner_change():
         ]
 
     assert storage.replace_sample_acls.call_args_list == [
-        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL('someuser', ['a'])), {}),
-        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL('someuser2', ['a'])), {})
+        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL(u('someuser'), [u('a')])), {}),
+        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL(u('someuser2'), [u('a')])), {})
         ]
 
 
@@ -469,18 +501,21 @@ def test_replace_sample_acls_with_owner_change_fail_lost_perms():
 
     storage.get_sample_acls.side_effect = [
         SampleACL(
-            'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x']),
+            u('someuser'),
+            [u('otheruser')],
+            [u('anotheruser'), u('ur mum')],
+            [u('Fungus J. Pustule Jr.'), u('x')]),
         SampleACL(
-            'someuser2', ['otheruser2', 'y'],)
+            u('someuser2'), [u('otheruser2'), u('y')],)
         ]
 
     storage.replace_sample_acls.side_effect = [OwnerChangedError, None]
 
     _replace_sample_acls_fail(
-        samples, id_, UserID('otheruser'), SampleACL('someuser', write=['b']),
+        samples, id_, UserID('otheruser'), SampleACL(u('someuser'), write=[u('b')]),
         UnauthorizedError(f'User otheruser cannot administrate sample {id_}'))
 
-    assert lu.are_valid_users.call_args_list == [((['b'],), {})]
+    assert lu.are_valid_users.call_args_list == [(([u('b')],), {})]
 
     assert storage.get_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),), {}),
@@ -488,7 +523,7 @@ def test_replace_sample_acls_with_owner_change_fail_lost_perms():
         ]
 
     assert storage.replace_sample_acls.call_args_list == [
-        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL('someuser', write=['b'])), {})
+        ((UUID('1234567890abcdef1234567890abcde0'), SampleACL(u('someuser'), write=[u('b')])), {})
         ]
 
 
@@ -503,16 +538,16 @@ def test_replace_sample_acls_with_owner_change_fail_5_times():
     lu.are_valid_users.return_value = []
 
     storage.get_sample_acls.side_effect = [
-        SampleACL(f'someuser{x}', ['otheruser']) for x in range(5)
+        SampleACL(u(f'someuser{x}'), [u('otheruser')]) for x in range(5)
     ]
 
     storage.replace_sample_acls.side_effect = OwnerChangedError
 
     _replace_sample_acls_fail(
-        samples, id_, UserID('otheruser'), SampleACL('someuser', read=['c']),
+        samples, id_, UserID('otheruser'), SampleACL(u('someuser'), read=[u('c')]),
         ValueError(f'Failed setting ACLs after 5 attempts for sample {id_}'))
 
-    assert lu.are_valid_users.call_args_list == [((['c'],), {})]
+    assert lu.are_valid_users.call_args_list == [(([u('c')],), {})]
 
     assert storage.get_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),), {}) for _ in range(5)
@@ -520,7 +555,7 @@ def test_replace_sample_acls_with_owner_change_fail_5_times():
 
     assert storage.replace_sample_acls.call_args_list == [
         ((UUID('1234567890abcdef1234567890abcde0'),
-            SampleACL(f'someuser{x}', read=['c']),), {}) for x in range(5)
+            SampleACL(u(f'someuser{x}'), read=[u('c')]),), {}) for x in range(5)
         ]
 
 
@@ -533,9 +568,9 @@ def test_replace_sample_acls_fail_bad_input():
     id_ = UUID('1234567890abcdef1234567890abcde0')
     u = UserID('u')
 
-    _replace_sample_acls_fail(samples, None, u, SampleACL('foo'), ValueError(
+    _replace_sample_acls_fail(samples, None, u, SampleACL(UserID('foo')), ValueError(
         'id_ cannot be a value that evaluates to false'))
-    _replace_sample_acls_fail(samples, id_, None, SampleACL('foo'), ValueError(
+    _replace_sample_acls_fail(samples, id_, None, SampleACL(UserID('foo')), ValueError(
         'user cannot be a value that evaluates to false'))
     _replace_sample_acls_fail(samples, id_, u, None, ValueError(
         'new_acls cannot be a value that evaluates to false'))
@@ -549,15 +584,19 @@ def test_replace_sample_acls_fail_nonexistent_user_4_users():
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
     id_ = UUID('1234567890abcdef1234567890abcde0')
 
-    lu.are_valid_users.return_value = ['whoo', 'yay', 'bugga', 'w']
+    lu.are_valid_users.return_value = [u('whoo'), u('yay'), u('bugga'), u('w')]
 
-    acls = SampleACL('foo', ['x', 'whoo'], ['yay', 'fwew'], ['y', 'bugga', 'z', 'w'])
+    acls = SampleACL(
+        u('foo'),
+        [u('x'), u('whoo')],
+        [u('yay'), u('fwew')],
+        [u('y'), u('bugga'), u('z'), u('w')])
 
     _replace_sample_acls_fail(
         samples, id_, UserID('foo'), acls, NoSuchUserError('whoo, yay, bugga, w'))
 
     assert lu.are_valid_users.call_args_list == [
-        ((['x', 'whoo', 'yay', 'fwew', 'y', 'bugga', 'z', 'w'],), {})]
+        (([u('x'), u('whoo'), u('yay'), u('fwew'), u('y'), u('bugga'), u('z'), u('w')],), {})]
 
 
 def test_replace_sample_acls_fail_nonexistent_user_5_users():
@@ -568,15 +607,20 @@ def test_replace_sample_acls_fail_nonexistent_user_5_users():
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
     id_ = UUID('1234567890abcdef1234567890abcde0')
 
-    lu.are_valid_users.return_value = ['whoo', 'yay', 'bugga', 'w', 'c']
+    lu.are_valid_users.return_value = [u('whoo'), u('yay'), u('bugga'), u('w'), u('c')]
 
-    acls = SampleACL('foo', ['x', 'whoo'], ['yay', 'fwew'], ['y', 'bugga', 'z', 'w', 'c'])
+    acls = SampleACL(
+        u('foo'),
+        [u('x'), u('whoo')],
+        [u('yay'), u('fwew')],
+        [u('y'), u('bugga'), u('z'), u('w'), u('c')])
 
     _replace_sample_acls_fail(
         samples, id_, UserID('foo'), acls, NoSuchUserError('whoo, yay, bugga, w, c'))
 
     assert lu.are_valid_users.call_args_list == [
-        ((['x', 'whoo', 'yay', 'fwew', 'y', 'bugga', 'z', 'w', 'c'],), {})]
+        (([u('x'), u('whoo'), u('yay'), u('fwew'), u('y'), u('bugga'), u('z'), u('w'),
+           u('c')],), {})]
 
 
 def test_replace_sample_acls_fail_nonexistent_user_6_users():
@@ -587,15 +631,20 @@ def test_replace_sample_acls_fail_nonexistent_user_6_users():
         storage, lu, meta, now=nw, uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
     id_ = UUID('1234567890abcdef1234567890abcde0')
 
-    lu.are_valid_users.return_value = ['whoo', 'yay', 'bugga', 'w', 'c', 'whee']
+    lu.are_valid_users.return_value = [u('whoo'), u('yay'), u('bugga'), u('w'), u('c'), u('whee')]
 
-    acls = SampleACL('foo', ['x', 'whoo'], ['yay', 'fwew'], ['y', 'bugga', 'z', 'w', 'c', 'whee'])
+    acls = SampleACL(
+        u('foo'),
+        [u('x'), u('whoo')],
+        [u('yay'), u('fwew')],
+        [u('y'), u('bugga'), u('z'), u('w'), u('c'), u('whee')])
 
     _replace_sample_acls_fail(
         samples, id_, UserID('foo'), acls, NoSuchUserError('whoo, yay, bugga, w, c'))
 
     assert lu.are_valid_users.call_args_list == [
-        ((['x', 'whoo', 'yay', 'fwew', 'y', 'bugga', 'z', 'w', 'c', 'whee'],), {})]
+        (([u('x'), u('whoo'), u('yay'), u('fwew'), u('y'), u('bugga'), u('z'), u('w'), u('c'),
+           u('whee')],), {})]
 
 
 def test_replace_sample_acls_fail_invalid_user():
@@ -608,12 +657,16 @@ def test_replace_sample_acls_fail_invalid_user():
 
     lu.are_valid_users.side_effect = user_lookup.InvalidUserError('o shit waddup')
 
-    acls = SampleACL('foo', ['o shit waddup', 'whoo'], ['yay', 'fwew'], ['y', 'bugga', 'z'])
+    acls = SampleACL(
+        u('foo'),
+        [u('o shit waddup'), u('whoo')],
+        [u('yay'), u('fwew')],
+        [u('y'), u('bugga'), u('z')])
 
     _replace_sample_acls_fail(samples, id_, UserID('foo'), acls, NoSuchUserError('o shit waddup'))
 
     assert lu.are_valid_users.call_args_list == [
-        ((['o shit waddup', 'whoo', 'yay', 'fwew', 'y', 'bugga', 'z'],), {})]
+        (([u('o shit waddup'), u('whoo'), u('yay'), u('fwew'), u('y'), u('bugga'), u('z')],), {})]
 
 
 def test_replace_sample_acls_fail_invalid_token():
@@ -626,13 +679,17 @@ def test_replace_sample_acls_fail_invalid_token():
 
     lu.are_valid_users.side_effect = user_lookup.InvalidTokenError('you big dummy')
 
-    acls = SampleACL('foo', ['x', 'whoo'], ['yay', 'fwew'], ['y', 'bugga', 'z'])
+    acls = SampleACL(
+        u('foo'),
+        [u('x'), u('whoo')],
+        [u('yay'), u('fwew')],
+        [u('y'), u('bugga'), u('z')])
 
     _replace_sample_acls_fail(samples, id_, UserID('foo'), acls, ValueError(
         'user lookup token for KBase auth server is invalid, cannot continue'))
 
     assert lu.are_valid_users.call_args_list == [
-        ((['x', 'whoo', 'yay', 'fwew', 'y', 'bugga', 'z'],), {})]
+        (([u('x'), u('whoo'), u('yay'), u('fwew'), u('y'), u('bugga'), u('z')],), {})]
 
 
 def test_replace_sample_acls_fail_unauthorized():
@@ -652,9 +709,12 @@ def _replace_sample_acls_fail_unauthorized(user: UserID):
     lu.are_valid_users.return_value = []
 
     storage.get_sample_acls.return_value = SampleACL(
-        'someuser', ['otheruser'], ['anotheruser', 'ur mum'], ['Fungus J. Pustule Jr.', 'x'])
+        u('someuser'),
+        [u('otheruser')],
+        [u('anotheruser'), u('ur mum')],
+        [u('Fungus J. Pustule Jr.'), u('x')])
 
-    _replace_sample_acls_fail(samples, id_, user, SampleACL('foo'), UnauthorizedError(
+    _replace_sample_acls_fail(samples, id_, user, SampleACL(u('foo')), UnauthorizedError(
         f'User {user} cannot administrate sample 12345678-90ab-cdef-1234-567890abcde0'))
 
     assert lu.are_valid_users.call_args_list == [(([],), {})]

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -687,7 +687,7 @@ def test_save_and_get_sample(samplestorage):
     assert samplestorage.get_sample(id_) == SavedSample(
         id_, UserID('auser'), [n1, n2, n3, n4], dt(8), 'foo', 1)
 
-    assert samplestorage.get_sample_acls(id_) == SampleACL('auser')
+    assert samplestorage.get_sample_acls(id_) == SampleACL(UserID('auser'))
 
 
 def test_save_sample_fail_bad_input(samplestorage):
@@ -1029,19 +1029,25 @@ def test_replace_sample_acls(samplestorage):
         SavedSample(id_, UserID('user'), [TEST_NODE], dt(1), 'foo')) is True
 
     samplestorage.replace_sample_acls(id_, SampleACL(
-        'user', ['foo', 'bar'], ['baz', 'bat'], ['whoo']))
+        UserID('user'),
+        [UserID('foo'), UserID('bar')],
+        [UserID('baz'), UserID('bat')],
+        [UserID('whoo')]))
 
     assert samplestorage.get_sample_acls(id_) == SampleACL(
-        'user', ['foo', 'bar'], ['baz', 'bat'], ['whoo'])
+        UserID('user'),
+        [UserID('foo'), UserID('bar')],
+        [UserID('baz'), UserID('bat')],
+        [UserID('whoo')])
 
-    samplestorage.replace_sample_acls(id_, SampleACL('user', write=['baz']))
+    samplestorage.replace_sample_acls(id_, SampleACL(UserID('user'), write=[UserID('baz')]))
 
-    assert samplestorage.get_sample_acls(id_) == SampleACL('user', write=['baz'])
+    assert samplestorage.get_sample_acls(id_) == SampleACL(UserID('user'), write=[UserID('baz')])
 
 
 def test_replace_sample_acls_fail_bad_args(samplestorage):
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(None, SampleACL('user'))
+        samplestorage.replace_sample_acls(None, SampleACL(UserID('user')))
     assert_exception_correct(got.value, ValueError(
         'id_ cannot be a value that evaluates to false'))
 
@@ -1060,7 +1066,7 @@ def test_replace_sample_acls_fail_no_sample(samplestorage):
     id2 = uuid.UUID('1234567890abcdef1234567890abcdea')
 
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(id2, SampleACL('user'))
+        samplestorage.replace_sample_acls(id2, SampleACL(UserID('user')))
     assert_exception_correct(got.value, NoSuchSampleError(str(id2)))
 
 
@@ -1079,7 +1085,7 @@ def test_replace_sample_acls_fail_owner_changed(samplestorage):
         bind_vars={'@col': 'samples', 'acls': {'owner': 'user2'}})
 
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(id_, SampleACL('user', write=['foo']))
+        samplestorage.replace_sample_acls(id_, SampleACL(UserID('user'), write=[UserID('foo')]))
     assert_exception_correct(got.value, OwnerChangedError())
 
 


### PR DESCRIPTION
lots of knock on effects again

Think that's it for bare usernames outside of the API layer