### PR TITLE
Add a max length for user names

### DIFF
--- a/lib/SampleService/core/user.py
+++ b/lib/SampleService/core/user.py
@@ -17,9 +17,9 @@ class UserID:
         '''
         Create the user id.
 
-        :param id: the user's id.
+        :param id: the user's id, a maximum of 256 unicode characters.
         '''
-        self.id = _check_string(userid, 'userid')
+        self.id = _check_string(userid, 'userid', max_len=256)
 
     def __str__(self):
         return self.id

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -1845,7 +1845,7 @@ def _expire_and_get_data_link_via_id(samplestorage, expired, dataid, expectedmd5
         dt(0.00056211),
         UserID('usera'),
         dt(expired),
-        UserID('user')  # TODO NOW max len for user 256 should be plenty
+        UserID('user')
         )
 
     assert samplestorage._col_data_link.count() == 1

--- a/test/core/user_test.py
+++ b/test/core/user_test.py
@@ -12,10 +12,10 @@ def test_init():
     assert u.id == 'foo'
     assert str(u) == 'foo'
 
-    u = UserID('u')
+    u = UserID('u' * 256)
 
-    assert u.id == 'u'
-    assert str(u) == 'u'
+    assert u.id == 'u' * 256
+    assert str(u) == 'u' * 256
 
     u = UserID('u⎇a')
 
@@ -27,6 +27,7 @@ def test_init_fail():
     _init_fail(None, MissingParameterError('userid'))
     _init_fail('   \t    ', MissingParameterError('userid'))
     _init_fail('foo \t bar', IllegalParameterError('userid contains control characters'))
+    _init_fail('u' * 257, IllegalParameterError('userid exceeds maximum length of 256'))
 
 
 def _init_fail(u, expected):


### PR DESCRIPTION
Since they're being stored in the db