### PR TITLE
Fix inconsistency in link design document

### DIFF
--- a/design/link_ws_data_to_sample_in_RE.md
+++ b/design/link_ws_data_to_sample_in_RE.md
@@ -96,9 +96,7 @@ in the RE database, not via workspace annotations.
     travelling queries.
 2. The SS checks that the user has read access to the UPA.
 3. The SS performs a traversal from the WSS shadow object in the RE through connected sample nodes
-   to the sample tree root, where the ACLs are stored. At minimum the user must be in the
-   read ACL of the sample.
-   * May need to restructure the ACL data structure in arango to make this doable.
+   to the sample tree root.
    * **OPEN QUESTION** May want to query on sample metadata.
       * May need to restructure the sample metadata to make this possible.
         * IIUC, only equality queries can be done on arrays of documents when using an index.


### PR DESCRIPTION
At the start of the document, it is explicitly said that if a user has
access to data, the user also has access to any linked samples and does
not need read permissions for the samples. This is contradicted later on in
the document. The first design is correct, and is how the link implementation
currently works. Remove the contradictory text.