### PR TITLE
Allow expiring links from deleted objects

### DIFF
--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -300,18 +300,22 @@ class Samples:
         '''
         Expire a data link, ensuring that it will not show up in link queries without an effective
         timestamp in the past.
-        The user must have admin access to the sample and write access to the data.
+        The user must have admin access to the sample and write access to the data. The data may
+        be deleted.
 
         :param user: the user expiring the link.
         :param duid: the data unit ID for the extant link.
         :raises UnauthorizedError: if the user does not have acceptable permissions.
-        :raises NoSuchWorkspaceDataError: if the workspace or UPA doesn't exist.
+        :raises NoSuchWorkspaceDataError: if the workspace doesn't exist.
         :raises NoSuchLinkError: if there is no link from the data unit.
         '''
         # TODO ADMIN admin mode
         _not_falsy(user, 'user')
         _not_falsy(duid, 'duid')
-        self._ws.has_permission(user, _WorkspaceAccessType.WRITE, upa=duid.upa)
+        # allow expiring links for deleted objects. It should be impossible to have a link
+        # for an object that has never existed.
+        # TODO DOCUMENT What about deleted workspaces? Links should be inaccessible as is
+        self._ws.has_permission(user, _WorkspaceAccessType.WRITE, workspace_id=duid.upa.wsid)
         link = self._storage.get_data_link(duid=duid)
         # was concerned about exposing the sample ID, but if the user has write access to the
         # UPA then they can get the link with the sample ID, so don't worry about it.

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -2004,14 +2004,22 @@ def test_expire_data_link_fail(sample_port, workspace):
         'dataid contains control characters')
     _expire_data_link_fail(
         sample_port, TOKEN4, {'upa': '1/1/1', 'dataid': 'yay'},
-        'Sample service error code 20000 Unauthorized: User user4 cannot write to upa 1/1/1')
+        'Sample service error code 20000 Unauthorized: User user4 cannot write to workspace 1')
+
+    wscli.delete_workspace({'id': 1})
+    _expire_data_link_fail(
+        sample_port, TOKEN3, {'upa': '1/1/1', 'dataid': 'yay'},
+        'Sample service error code 50040 No such workspace data: Workspace 1 is deleted')
+
+    wsadmin = Workspace(wsurl, token=TOKEN_WS_FULL_ADMIN)
+    wsadmin.administer({'command': 'undeleteWorkspace', 'params': {'id': 1}})
     _expire_data_link_fail(
         sample_port, TOKEN3, {'upa': '1/1/2', 'dataid': 'yay'},
-        'Sample service error code 50040 No such workspace data: Object 1/1/2 does not exist')
-    # TODO NOW don't check object exists for expire link, allow expire on deleted objects
+        'Sample service error code 50050 No such data link: 1/1/2:yay')
     _expire_data_link_fail(
         sample_port, TOKEN3, {'upa': '1/1/1', 'dataid': 'yee'},
         'Sample service error code 50050 No such data link: 1/1/1:yee')
+
     wscli.set_permissions({'id': 1, 'new_permission': 'w', 'users': [USER4]})
     _expire_data_link_fail(
         sample_port, TOKEN4, {'upa': '1/1/1', 'dataid': 'yay'},

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -1354,7 +1354,7 @@ def _expire_data_link(user):
     s.expire_data_link(user, DataUnitID(UPA('6/1/2'), 'foo'))
 
     ws.has_permission.assert_called_once_with(
-        user, WorkspaceAccessType.WRITE, upa=UPA('6/1/2'))
+        user, WorkspaceAccessType.WRITE, workspace_id=6)
 
     storage.get_data_link.assert_called_once_with(duid=DataUnitID(UPA('6/1/2'), 'foo'))
     storage.get_sample_acls.assert_called_once_with(sid)
@@ -1388,7 +1388,7 @@ def test_expire_data_link_fail_no_ws_access():
                            UnauthorizedError('oh honey boo boo foofy foo'))
 
     ws.has_permission.assert_called_once_with(
-        UserID('u'), WorkspaceAccessType.WRITE, upa=UPA('1/1/1'))
+        UserID('u'), WorkspaceAccessType.WRITE, workspace_id=1)
 
 
 def test_expire_data_link_fail_no_link():
@@ -1404,7 +1404,7 @@ def test_expire_data_link_fail_no_link():
                            NoSuchLinkError('oh lordy'))
 
     ws.has_permission.assert_called_once_with(
-        UserID('a'), WorkspaceAccessType.WRITE, upa=UPA('6/1/2'))
+        UserID('a'), WorkspaceAccessType.WRITE, workspace_id=6)
 
     storage.get_data_link.assert_called_once_with(duid=DataUnitID(UPA('6/1/2'), 'foo'))
 
@@ -1425,7 +1425,7 @@ def _expire_data_link_fail_no_sample_access(user):
     sid = UUID('1234567890abcdef1234567890abcdee')
     storage.get_data_link.return_value = DataLink(
         uuid.uuid4(),  # unused
-        DataUnitID(UPA('6/1/2'), 'foo'),
+        DataUnitID(UPA('9/1/2'), 'foo'),
         SampleNodeAddress(SampleAddress(sid, 3), 'node'),
         dt(34),
         UserID('userc')
@@ -1437,13 +1437,13 @@ def _expire_data_link_fail_no_sample_access(user):
         [u('anotheruser'), u('ur mum')],
         [u('Fungus J. Pustule Jr.'), u('x')])
 
-    _expire_data_link_fail(s, user, DataUnitID(UPA('6/1/2'), 'foo'),
+    _expire_data_link_fail(s, user, DataUnitID(UPA('9/1/2'), 'foo'),
                            UnauthorizedError(f'User {user} cannot administrate sample {sid}'))
 
     ws.has_permission.assert_called_once_with(
-        user, WorkspaceAccessType.WRITE, upa=UPA('6/1/2'))
+        user, WorkspaceAccessType.WRITE, workspace_id=9)
 
-    storage.get_data_link.assert_called_once_with(duid=DataUnitID(UPA('6/1/2'), 'foo'))
+    storage.get_data_link.assert_called_once_with(duid=DataUnitID(UPA('9/1/2'), 'foo'))
     storage.get_sample_acls.assert_called_once_with(sid)
 
 
@@ -1479,7 +1479,7 @@ def test_expire_data_link_fail_no_link_at_storage():
                            NoSuchLinkError("dang y'all"))
 
     ws.has_permission.assert_called_once_with(
-        UserID('y'), WorkspaceAccessType.WRITE, upa=UPA('6/1/2'))
+        UserID('y'), WorkspaceAccessType.WRITE, workspace_id=6)
 
     storage.get_data_link.assert_called_once_with(duid=DataUnitID(UPA('6/1/2')))
     storage.get_sample_acls.assert_called_once_with(sid)


### PR DESCRIPTION
Not sure what to do about deleted workspaces. Document issue for now.
Maybe auto expire if workspace is deleted? But what about undelete?
Links shouldn't be visible to users anyway with current access methods.