### PR TITLE
Consistently use _ in validator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,11 @@ The configuration file uses the YAML format and is validated against the followi
                             'type': 'object',
                             'properties': {
                                 'module': {'type': 'string'},
-                                'callable-builder': {'type': 'string'},
+                                'callable_builder': {'type': 'string'},
                                 'parameters': {'type': 'object'}
                             },
                             'additionalProperties': False,
-                            'required': ['module', 'callable-builder']
+                            'required': ['module', 'callable_builder']
                         }
 
                     }
@@ -281,7 +281,7 @@ The configuration consists of a mapping of standard and prefix metadata keys to 
 of metadata key properties, including the list of validator specifications and static metadata
 about the key. Each validator is run against the metadata value in order. The `module` key is
 a python import path for the module containing a builder function for the validator, while the
-`callable-builder` key is the name of the function within the module that can be called to 
+`callable_builder` key is the name of the function within the module that can be called to 
 create the validator. `parameters` contains a mapping that is passed directly to the
 callable builder. The builder is expected to return a callable with the call signature as
 described previously.
@@ -292,18 +292,18 @@ validators:
     foo:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: noop
+              callable_builder: noop
         key_metadata:
             description: test key
             semantics: none really
     stringlen:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: string
+              callable_builder: string
               parameters:
                   max-len: 5
             - module: SampleService.core.validator.builtin
-              callable-builder: string
+              callable_builder: string
               parameters:
                   keys: spcky
                   max-len: 2
@@ -313,7 +313,7 @@ prefix_validators:
     gene_ontology_:
         validators:
             - module: geneontology.plugins.kbase
-              callable-builder: go_builder
+              callable_builder: go_builder
               parameters: 
                   url: https://fake.go.service.org/api/go
                   apitoken: abcdefg-hijklmnop
@@ -352,7 +352,7 @@ validators:
     metadatakey:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: noop
+              callable_builder: noop
 ```
 
 This validator accepts any and all values.
@@ -365,7 +365,7 @@ validators:
     metadatakey:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: string
+              callable_builder: string
               parameters:
                   keys: ['key1', 'key2']
                   required: True
@@ -388,7 +388,7 @@ validators:
     metadatakey:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: enum
+              callable_builder: enum
               parameters:
                   keys: ['key1', 'key2']
                   allowed-values: ['red', 'blue', 'green]
@@ -408,7 +408,7 @@ validators:
     metadatakey:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: units
+              callable_builder: units
               parameters:
                   key: 'units'
                   units: 'mg/L'
@@ -428,7 +428,7 @@ validators:
     metadatakey:
         validators:
             - module: SampleService.core.validator.builtin
-              callable-builder: number
+              callable_builder: number
               parameters:
                   keys: ['length', 'width']
                   type: int

--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -163,11 +163,16 @@ _META_VAL_JSONSCHEMA = {
                             'type': 'object',
                             'properties': {
                                 'module': {'type': 'string'},
-                                'callable-builder': {'type': 'string'},
+                                'callable-builder': {'type': 'string'},  # TODO SCHEMA remove
+                                'callable_builder': {'type': 'string'},
                                 'parameters': {'type': 'object'}
                             },
                             'additionalProperties': False,
-                            'required': ['module', 'callable-builder']
+                            'required': ['module'],
+                            'oneOf': [
+                                {'required': ['callable_builder']},
+                                {'required': ['callable-builder']},
+                            ]
                         }
 
                     }
@@ -224,8 +229,11 @@ def _get_validators(cfg, name_, metaval_func) -> List[_MetadataValidator]:
         for i, val in enumerate(keyval['validators']):
             m = importlib.import_module(val['module'])
             p = val.get('parameters', {})
+            cb = val.get('callable_builder')  # TODO SCHEMA switch to []
+            if not cb:
+                cb = val['callable-builder']  # TODO SCHEMA remove
             try:
-                build_func = getattr(m, val['callable-builder'])
+                build_func = getattr(m, cb)
                 lvals.append(build_func(p))
             except Exception as e:
                 raise ValueError(

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -55,21 +55,21 @@ def test_config_get_validators(temp_dir):
     cfg = {
         'validators': {
             'key1': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'val1'
+                                     'callable-builder': 'val1'  # TODO SCHEMA switch to _
                                      }],
                      'key_metadata': {'a': 'b', 'c': 1.56}
                      },
             'key2': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'val2',
+                                     'callable_builder': 'val2',
                                      'parameters': {'max-len': 7, 'foo': 'bar'}
                                      },
                                     {'module': 'core.config_test_vals',
-                                     'callable-builder': 'val2',
+                                     'callable_builder': 'val2',
                                      'parameters': {'max-len': 5, 'foo': 'bar'},
                                      }],
                      },
             'key3': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'val1',
+                                     'callable_builder': 'val1',
                                      'parameters': {'foo': 'bat'}
                                      }],
                      'key_metadata': {'f': None, 'g': 1}
@@ -77,22 +77,22 @@ def test_config_get_validators(temp_dir):
         },
         'prefix_validators': {
             'key4': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'pval1',
+                                     'callable_builder': 'pval1',
                                      }],
                      },
             # check key3 doesn't interfere with above key3
             'key3': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'pval2',
+                                     'callable_builder': 'pval2',
                                      'parameters': {'max-len': 7, 'foo': 'bar'},
                                      },
                                     {'module': 'core.config_test_vals',
-                                     'callable-builder': 'pval2',
+                                     'callable_builder': 'pval2',
                                      'parameters': {'max-len': 5, 'foo': 'bar'}
                                      }],
                      'key_metadata': {'h': True, 'i': 1000}
                      },
             'key5': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'pval1',
+                                     'callable_builder': 'pval1',
                                      'parameters': {'foo': 'bat'}
                                      }],
                      'key_metadata': {'a': 'f', 'c': 'l'}
@@ -214,12 +214,12 @@ def _config_get_validators_fail_bad_params(temp_dir, key_):
         ValidationError("'foo' is not of type 'object'"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable-builder': 'bar'}],
+                                        'callable_builder': 'bar'}],
                         'key_metadata': []}}},
         temp_dir, ValidationError("[] is not of type 'object'"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable-builder': 'bar'}],
+                                        'callable_builder': 'bar'}],
                         'key_metadata': {'a': {}}}}},
         temp_dir, ValidationError("{} is not of type 'number', 'boolean', 'string', 'null'"))
     _config_get_validators_fail(
@@ -227,24 +227,32 @@ def _config_get_validators_fail_bad_params(temp_dir, key_):
         ValidationError("'module' is a required property"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo'}]}}}, temp_dir,
-        ValidationError("'callable-builder' is a required property"))
+        ValidationError("'callable_builder' is a required property"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable-builder': 'bar',
+                                        'callable_builder': 'baz',
+                                        'callable-builder': 'bar'}]}}},
+        temp_dir,
+        ValidationError(
+            "{'callable-builder': 'bar', 'callable_builder': 'baz', 'module': 'foo'} is valid " +
+            "under each of {'required': ['callable-builder']}, {'required': ['callable_builder']}"))
+    _config_get_validators_fail(
+        {key_: {'key': {'validators': [{'module': 'foo',
+                                        'callable_builder': 'bar',
                                         'prefix': 1}]}}},
         temp_dir,
         ValidationError("Additional properties are not allowed ('prefix' was unexpected)"))
     _config_get_validators_fail(
-        {key_: {'key': {'validators': [{'module': ['foo'], 'callable-builder': 'bar'}]}}},
+        {key_: {'key': {'validators': [{'module': ['foo'], 'callable_builder': 'bar'}]}}},
         temp_dir,
         ValidationError("['foo'] is not of type 'string'"))
     _config_get_validators_fail(
-        {key_: {'key': {'validators': [{'module': 'foo', 'callable-builder': ['bar']}]}}},
+        {key_: {'key': {'validators': [{'module': 'foo', 'callable_builder': ['bar']}]}}},
         temp_dir,
         ValidationError("['bar'] is not of type 'string'"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable-builder': 'bar',
+                                        'callable_builder': 'bar',
                                         'parameters': 'foo'}]}}},
         temp_dir,
         ValidationError("'foo' is not of type 'object'"))
@@ -253,7 +261,7 @@ def _config_get_validators_fail_bad_params(temp_dir, key_):
 def test_config_get_validators_fail_no_module(temp_dir):
     _config_get_validators_fail(
         {'validators': {'key': {'validators': [{'module': 'no_modules_here',
-                                                'callable-builder': 'foo'}]}}},
+                                                'callable_builder': 'foo'}]}}},
         temp_dir,
         ModuleNotFoundError("No module named 'no_modules_here'"))
 
@@ -261,7 +269,7 @@ def test_config_get_validators_fail_no_module(temp_dir):
 def test_config_get_validators_fail_no_function(temp_dir):
     _config_get_validators_fail(
         {'validators': {'x': {'validators': [{'module': 'core.config_test_vals',
-                                              'callable-builder': 'foo'}]}}},
+                                              'callable_builder': 'foo'}]}}},
         temp_dir,
         ValueError("Metadata validator callable build #0 failed for key x: " +
                    "module 'core.config_test_vals' has no attribute 'foo'"))
@@ -270,9 +278,9 @@ def test_config_get_validators_fail_no_function(temp_dir):
 def test_config_get_validators_fail_function_exception(temp_dir):
     _config_get_validators_fail(
         {'validators': {'x': {'validators': [{'module': 'core.config_test_vals',
-                                              'callable-builder': 'val1'},
+                                              'callable_builder': 'val1'},
                                              {'module': 'core.config_test_vals',
-                                              'callable-builder': 'fail_val'}]}}},
+                                              'callable_builder': 'fail_val'}]}}},
         temp_dir,
         ValueError("Metadata validator callable build #1 failed for key x: " +
                    "we've no functions 'ere"))
@@ -281,11 +289,11 @@ def test_config_get_validators_fail_function_exception(temp_dir):
 def test_config_get_prefix_validators_fail_function_exception(temp_dir):
     _config_get_validators_fail(
         {'prefix_validators': {'p': {'validators': [{'module': 'core.config_test_vals',
-                                                     'callable-builder': 'val1'},
+                                                     'callable_builder': 'val1'},
                                                     {'module': 'core.config_test_vals',
-                                                     'callable-builder': 'val1'},
+                                                     'callable_builder': 'val1'},
                                                     {'module': 'core.config_test_vals',
-                                                     'callable-builder': 'fail_prefix_val'}
+                                                     'callable_builder': 'fail_prefix_val'}
                                                     ]}}},
         temp_dir,
         ValueError('Prefix metadata validator callable build #2 failed for key p: ' +


### PR DESCRIPTION
Allow `-` as well for now, but remove soon (after Sebastian updates cfg yml)

Intentionally do not document the soon to be removed `-` form

Fixes https://github.com/kbase/sample_service/issues/285