### PR TITLE
Remove callable-builder as a validator config key

### DIFF
--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -163,16 +163,11 @@ _META_VAL_JSONSCHEMA = {
                             'type': 'object',
                             'properties': {
                                 'module': {'type': 'string'},
-                                'callable-builder': {'type': 'string'},  # TODO SCHEMA remove
                                 'callable_builder': {'type': 'string'},
                                 'parameters': {'type': 'object'}
                             },
                             'additionalProperties': False,
-                            'required': ['module'],
-                            'oneOf': [
-                                {'required': ['callable_builder']},
-                                {'required': ['callable-builder']},
-                            ]
+                            'required': ['module', 'callable_builder']
                         }
 
                     }
@@ -229,11 +224,8 @@ def _get_validators(cfg, name_, metaval_func) -> List[_MetadataValidator]:
         for i, val in enumerate(keyval['validators']):
             m = importlib.import_module(val['module'])
             p = val.get('parameters', {})
-            cb = val.get('callable_builder')  # TODO SCHEMA switch to []
-            if not cb:
-                cb = val['callable-builder']  # TODO SCHEMA remove
             try:
-                build_func = getattr(m, cb)
+                build_func = getattr(m, val['callable_builder'])
                 lvals.append(build_func(p))
             except Exception as e:
                 raise ValueError(

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -111,16 +111,16 @@ def create_deploy_cfg(auth_port, arango_port, workspace_port):
     metacfg = {
         'validators': {
             'foo': {'validators': [{'module': 'SampleService.core.validator.builtin',
-                                    'callable-builder': 'noop'
+                                    'callable_builder': 'noop'
                                     }],
                     'key_metadata': {'a': 'b', 'c': 'd'}
                     },
             'stringlentest': {'validators': [{'module': 'SampleService.core.validator.builtin',
-                                              'callable-builder': 'string',
+                                              'callable_builder': 'string',
                                               'parameters': {'max-len': 5}
                                               },
                                              {'module': 'SampleService.core.validator.builtin',
-                                              'callable-builder': 'string',
+                                              'callable_builder': 'string',
                                               'parameters': {'keys': 'spcky', 'max-len': 2}
                                               }],
                               'key_metadata': {'h': 'i', 'j': 'k'}
@@ -128,7 +128,7 @@ def create_deploy_cfg(auth_port, arango_port, workspace_port):
         },
         'prefix_validators': {
             'pre': {'validators': [{'module': 'core.config_test_vals',
-                                    'callable-builder': 'prefix_validator_test_builder',
+                                    'callable_builder': 'prefix_validator_test_builder',
                                     'parameters': {'fail_on_arg': 'fail_plz'}
                                     }],
                     'key_metadata': {'1': '2'}

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -55,7 +55,7 @@ def test_config_get_validators(temp_dir):
     cfg = {
         'validators': {
             'key1': {'validators': [{'module': 'core.config_test_vals',
-                                     'callable-builder': 'val1'  # TODO SCHEMA switch to _
+                                     'callable_builder': 'val1'
                                      }],
                      'key_metadata': {'a': 'b', 'c': 1.56}
                      },
@@ -229,13 +229,10 @@ def _config_get_validators_fail_bad_params(temp_dir, key_):
         {key_: {'key': {'validators': [{'module': 'foo'}]}}}, temp_dir,
         ValidationError("'callable_builder' is a required property"))
     _config_get_validators_fail(
-        {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable_builder': 'baz',
-                                        'callable-builder': 'bar'}]}}},
+        {key_: {'key': {'validators': [{'module': 'foo', 'callable-builder': 'bar'}]}}},
         temp_dir,
         ValidationError(
-            "{'callable-builder': 'bar', 'callable_builder': 'baz', 'module': 'foo'} is valid " +
-            "under each of {'required': ['callable-builder']}, {'required': ['callable_builder']}"))
+            "Additional properties are not allowed ('callable-builder' was unexpected)"))
     _config_get_validators_fail(
         {key_: {'key': {'validators': [{'module': 'foo',
                                         'callable_builder': 'bar',


### PR DESCRIPTION
Replaced by callable_builder

Fixes https://github.com/kbase/sample_service/issues/285