### PR TITLE
Integrate kafka notifier into service

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ coveralls = "*"
 flake8 = "*"
 pymongo = "*"
 semver = "*"
+ipython = "*"
 
 [packages]
 python-arango = "==5.0.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "95de0d8b679b366d403b7f535051b612c4b6e8ff469ffc07fb31dfeed3a0fa67"
+            "sha256": "78a2d3911fee178c81c2107f5d91f41bbe05004e61b6a97711c9559d342f16be"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -313,6 +313,13 @@
             ],
             "version": "==19.3.0"
         },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
@@ -371,6 +378,13 @@
             "index": "pypi",
             "version": "==2.0.0"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
+                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
+            ],
+            "version": "==4.4.2"
+        },
         "docopt": {
             "hashes": [
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
@@ -399,6 +413,28 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==1.6.0"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:5b241b84bbf0eb085d43ae9d46adf38a13b45929ca7774a740990c2c242534bb",
+                "sha256:f0126781d0f959da852fb3089e170ed807388e986a8dd4e6ac44855845b0fb1c"
+            ],
+            "index": "pypi",
+            "version": "==7.14.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:cd60c93b71944d628ccac47df9a60fec53150de53d42dc10a7fc4b5ba6aae798",
+                "sha256:df40c97641cb943661d2db4c33c2e1ff75d491189423249e989bcea4464f3030"
+            ],
+            "version": "==0.17.0"
         },
         "mccabe": {
             "hashes": [
@@ -448,12 +484,48 @@
             ],
             "version": "==20.4"
         },
+        "parso": {
+            "hashes": [
+                "sha256:158c140fc04112dc45bca311633ae5033c2c2a7b732fa33d0955bad8152a8dd0",
+                "sha256:908e9fae2144a076d72ae4e25539143d40b8e3eafbaeae03c1bfe226f4cdf12c"
+            ],
+            "version": "==0.7.0"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
             "version": "==0.13.1"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:563d1a4140b63ff9dd587bda9557cffb2fe73650205ab6f4383092fb882e7dc8",
+                "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
+            ],
+            "version": "==3.0.5"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
         },
         "py": {
             "hashes": [
@@ -475,6 +547,13 @@
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
             "version": "==2.2.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+            ],
+            "version": "==2.6.1"
         },
         "pymongo": {
             "hashes": [
@@ -580,6 +659,13 @@
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
             "version": "==1.15.0"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44",
+                "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
+            ],
+            "version": "==4.3.3"
         },
         "typed-ast": {
             "hashes": [

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -71,3 +71,10 @@ schema-collection = {{ schema_collection }}
 # A URL pointing to a configuration file for any metadata validators to be installed on startup.
 # See the readme file for a description of the file contents.
 metadata-validator-config-url = {{ metadata_validator_config_url }}
+
+# bootstrap.servers parameter for Kafka notifications. Leave blank to disable the Kafka
+# notifier.
+kafka-bootstrap-servers = {{ kafka_bootstrap_servers }}
+# The topic to which the Kafka notifier should write. Required if kafka-bootstrap-servers is
+# provided.
+kafka-topic = {{ kafka_topic }}

--- a/test/kafka_controller.py
+++ b/test/kafka_controller.py
@@ -148,6 +148,8 @@ class KafkaController:
         """
         Remove all records from a topic.
 
+        Note this takes about 2 seconds.
+
         :param topic: the topic to clear.
         """
         exe = self._bin_dir.joinpath(self._KAFKA_TOPIC_EXE)
@@ -159,6 +161,8 @@ class KafkaController:
     def clear_all_topics(self):
         """
         Remove all records from all topics.
+
+        Note this takes about 2 seconds per topic.
         """
         cons = KafkaConsumer(bootstrap_servers=[f'localhost:{self.port}'], group_id='foo')
         for topic in cons.topics():
@@ -194,8 +198,8 @@ class KafkaController:
             if dump_logs_to_stdout:
                 print(f'\n{name} logs:')
                 with open(file_.name) as f:
-                    for l in f:
-                        print(l)
+                    for line in f:
+                        print(line)
 
 
 def main():

--- a/test/mongo_controller.py
+++ b/test/mongo_controller.py
@@ -76,9 +76,9 @@ class MongoController:
 
         # get some info about the db
         self.db_version = self.client.server_info()['version']
-        self.index_version = 2 if (semver.compare(self.db_version, '3.4.0') >= 0) else 1
-        self.includes_system_indexes = (semver.compare(self.db_version, '3.2.0') < 0
-                                        and not use_wired_tiger)
+        s = semver.VersionInfo.parse
+        self.index_version = 2 if (s(self.db_version) >= s('3.4.0')) else 1
+        self.includes_system_indexes = (s(self.db_version) < s('3.2.0') and not use_wired_tiger)
 
     def destroy(self, delete_temp_files: bool) -> None:
         """


### PR DESCRIPTION
That was a major pain.
* deleting a topic & contents takes ~2s locally, tripled test time when
  run after every test
* Kafka consumer polling is pretty slow, and can't be done mid test if
  assert _close_to_now is used.
* It seems as though not closing clients can cause weird errors/hangs in
  other clients? Not 100% sure about this, was making too many changes
  too rapidly trying to figure out what was going on. Closing doesn't seem
  to hurt  though.

also flake8 mysteriously started whining about new stuff even though it
wasn't updated.