### PR TITLE
Record time sample acls are changed

### DIFF
--- a/lib/SampleService/core/api_translation.py
+++ b/lib/SampleService/core/api_translation.py
@@ -293,6 +293,7 @@ def acls_to_dict(acls: SampleACL) -> Dict[str, Any]:
     :param acls: The ACLs to convert.
     :return: the ACLs as a dict.
     '''
+    # don't expose mod time for now, could do later
     return {'owner': _not_falsy(acls, 'acls').owner.id,
             'admin': tuple(u.id for u in acls.admin),
             'write': tuple(u.id for u in acls.write),

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -236,7 +236,8 @@ class Samples:
                 raise ValueError(f'Failed setting ACLs after 5 attempts for sample {id_}')
             acls = self._storage.get_sample_acls(id_)
             self._check_perms(id_, user, _SampleAccessType.ADMIN, acls, as_admin=as_admin)
-            new_acls = SampleACL(acls.owner, new_acls.admin, new_acls.write, new_acls.read)
+            new_acls = SampleACL(
+                acls.owner, self._now(), new_acls.admin, new_acls.write, new_acls.read)
             try:
                 self._storage.replace_sample_acls(id_, new_acls)
                 count = -1

--- a/test/core/api_translation_test.py
+++ b/test/core/api_translation_test.py
@@ -459,7 +459,7 @@ def test_sample_to_dict_fail():
 
 
 def test_acls_to_dict_minimal():
-    assert acls_to_dict(SampleACL(UserID('user'))) == {
+    assert acls_to_dict(SampleACL(UserID('user'), dt(1))) == {
         'owner': 'user',
         'admin': (),
         'write': (),
@@ -471,6 +471,7 @@ def test_acls_to_dict_maximal():
     assert acls_to_dict(
         SampleACL(
             UserID('user'),
+            dt(1),
             [UserID('foo'), UserID('bar')],
             [UserID('baz')],
             [UserID('hello'), UserID("I'm"), UserID('a'), UserID('robot')])) == {

--- a/test/core/sample_test.py
+++ b/test/core/sample_test.py
@@ -81,7 +81,7 @@ def test_sample_node_build_fail_metadata():
 
     _sample_node_build_fail_metadata(
         {'wh\tee': {}},
-        f"{{}} metadata key wh\tee's character at index 2 is a control character.")
+        "{} metadata key wh\tee's character at index 2 is a control character.")
 
     _sample_node_build_fail_metadata(
         {'bat': {'a' * 255 + 'ff': 'whee'}},
@@ -90,12 +90,12 @@ def test_sample_node_build_fail_metadata():
 
     _sample_node_build_fail_metadata(
         {'wugga': {'wh\tee': {}}},
-        f"{{}} metadata value key wh\tee under key wugga's character at index 2 is a " +
+        "{} metadata value key wh\tee under key wugga's character at index 2 is a " +
         "control character.")
 
     _sample_node_build_fail_metadata(
         {'bat': {'whee': 'a' * 255 + 'f' * 770}},
-        f"{{}} metadata has value under root key bat and value key whee starting with " +
+        "{} metadata has value under root key bat and value key whee starting with " +
         f"{'a' * 255 + 'f'} that exceeds maximum length of 1024")
 
     _sample_node_build_fail_metadata(

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -688,7 +688,7 @@ def test_save_and_get_sample(samplestorage):
     assert samplestorage.get_sample(id_) == SavedSample(
         id_, UserID('auser'), [n1, n2, n3, n4], dt(8), 'foo', 1)
 
-    assert samplestorage.get_sample_acls(id_) == SampleACL(UserID('auser'))
+    assert samplestorage.get_sample_acls(id_) == SampleACL(UserID('auser'), dt(8))
 
 
 def test_save_sample_fail_bad_input(samplestorage):
@@ -1031,24 +1031,27 @@ def test_replace_sample_acls(samplestorage):
 
     samplestorage.replace_sample_acls(id_, SampleACL(
         UserID('user'),
+        dt(56),
         [UserID('foo'), UserID('bar')],
         [UserID('baz'), UserID('bat')],
         [UserID('whoo')]))
 
     assert samplestorage.get_sample_acls(id_) == SampleACL(
         UserID('user'),
+        dt(56),
         [UserID('foo'), UserID('bar')],
         [UserID('baz'), UserID('bat')],
         [UserID('whoo')])
 
-    samplestorage.replace_sample_acls(id_, SampleACL(UserID('user'), write=[UserID('baz')]))
+    samplestorage.replace_sample_acls(id_, SampleACL(UserID('user'), dt(83), write=[UserID('baz')]))
 
-    assert samplestorage.get_sample_acls(id_) == SampleACL(UserID('user'), write=[UserID('baz')])
+    assert samplestorage.get_sample_acls(id_) == SampleACL(
+        UserID('user'), dt(83), write=[UserID('baz')])
 
 
 def test_replace_sample_acls_fail_bad_args(samplestorage):
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(None, SampleACL(UserID('user')))
+        samplestorage.replace_sample_acls(None, SampleACL(UserID('user'), dt(1)))
     assert_exception_correct(got.value, ValueError(
         'id_ cannot be a value that evaluates to false'))
 
@@ -1067,7 +1070,7 @@ def test_replace_sample_acls_fail_no_sample(samplestorage):
     id2 = uuid.UUID('1234567890abcdef1234567890abcdea')
 
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(id2, SampleACL(UserID('user')))
+        samplestorage.replace_sample_acls(id2, SampleACL(UserID('user'), dt(1)))
     assert_exception_correct(got.value, NoSuchSampleError(str(id2)))
 
 
@@ -1086,7 +1089,8 @@ def test_replace_sample_acls_fail_owner_changed(samplestorage):
         bind_vars={'@col': 'samples', 'acls': {'owner': 'user2'}})
 
     with raises(Exception) as got:
-        samplestorage.replace_sample_acls(id_, SampleACL(UserID('user'), write=[UserID('foo')]))
+        samplestorage.replace_sample_acls(
+            id_, SampleACL(UserID('user'), dt(1), write=[UserID('foo')]))
     assert_exception_correct(got.value, OwnerChangedError())
 
 


### PR DESCRIPTION
This will be needed for resending Kafka messages in a date range, e.g.
looking for updates in a given time range.

Not exposed in API for now.