### PR TITLE
Fix public read bug

### DIFF
--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -237,7 +237,12 @@ class Samples:
             acls = self._storage.get_sample_acls(id_)
             self._check_perms(id_, user, _SampleAccessType.ADMIN, acls, as_admin=as_admin)
             new_acls = SampleACL(
-                acls.owner, self._now(), new_acls.admin, new_acls.write, new_acls.read)
+                acls.owner,
+                self._now(),
+                new_acls.admin,
+                new_acls.write,
+                new_acls.read,
+                new_acls.public_read)
             try:
                 self._storage.replace_sample_acls(id_, new_acls)
                 count = -1


### PR DESCRIPTION
In samples.py the acl class is not passed all the way through.
This was missed in the first PR but caught by integration tests.