### PR TITLE
Support anonymous users in ws wrapper has_permission method

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,11 @@
   * cache known good users
   * cache user roles
   * support anonymous users
+    * get sample
+    * get sample acls
+    * get links from sample
+    * get links from data
+    * get sample via data
   * remove self from acls (read/write)
   * change sample owner
     * Probably needs request / accept multistep flow


### PR DESCRIPTION
Requires supporting public workspaces as well, which up to now were not supported.

Added a couple of integration tests for public workspaces for the 2 methods
that only require read access now that public workspaces work.