### PR TITLE
Add is_update method to SampleACL

### DIFF
--- a/test/core/acls_test.py
+++ b/test/core/acls_test.py
@@ -199,8 +199,8 @@ def test_is_update():
     assert s.is_update(SampleACLDelta(dt(2), read=[u('r1')])) is False
     assert s.is_update(SampleACLDelta(dt(2), read=[u('r3')])) is True
 
-    assert s.is_update(SampleACLDelta(dt(2), remove=[u('r1')])) is True
-    assert s.is_update(SampleACLDelta(dt(2), remove=[u('r3')])) is False
+    assert s.is_update(SampleACLDelta(dt(2), remove=[u('a1')])) is True
+    assert s.is_update(SampleACLDelta(dt(2), remove=[u('a3')])) is False
 
     assert s.is_update(SampleACLDelta(dt(2), remove=[u('w2')])) is True
     assert s.is_update(SampleACLDelta(dt(2), remove=[u('w4')])) is False


### PR DESCRIPTION
Checks if a SampleACLDelta is actually an update.
Originally in the ArangoSampleStorage class but testing it there was a pain.
Easier here and more resuable.