### PR TITLE
Step 1 in separating update time from update ACLs

### DIFF
--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -278,7 +278,7 @@ class Samples:
             update.remove,
             update.public_read
         )
-        self._storage.update_sample_acls(id_, update)
+        self._storage.update_sample_acls(id_, update, self._now())
         if self._kafka:
             self._kafka.notify_sample_acl_change(id_)
 

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -884,7 +884,8 @@ def _update_sample_acls(user: UserID, public_read):
             [u('z'), u('a')],
             [u('b'), u('c')],
             [u('r'), u('q')],
-            public_read))
+            public_read),
+        dt(6))
 
     kafka.notify_sample_acl_change.assert_called_once_with(
         UUID('1234567890abcdef1234567890abcde0'))
@@ -927,7 +928,8 @@ def test_update_sample_acls_as_admin_without_notifier():
             [u('z'), u('a')],
             [u('b'), u('c')],
             [u('r'), u('q')],
-            None))
+            None),
+        dt(6))
 
 
 def test_update_sample_acls_fail_bad_input():


### PR DESCRIPTION
No need for them to be in the same class, makes the API more complicated
than it needs to be