### PR TITLE
Fix acl update bug

### DIFF
--- a/lib/SampleService/core/acls.py
+++ b/lib/SampleService/core/acls.py
@@ -18,6 +18,8 @@ from SampleService.core.errors import (
 )
 from SampleService.core.user import UserID
 
+# may need to add sane limits on ACL sizes if people act like jerks
+
 
 class SampleAccessType(IntEnum):
     '''


### PR DESCRIPTION
When a user already exists in an ACL, adding them to another ACL  wouldn't
remove them from the first