### PR TITLE
Add option to update acls without demoting current users in DB layer

### DIFF
--- a/lib/SampleService/core/acls.py
+++ b/lib/SampleService/core/acls.py
@@ -251,3 +251,7 @@ class SampleACL(SampleACLOwnerless):
     def __hash__(self):
         return hash((self.owner, self.lastupdate, self.admin, self.write, self.read,
                      self.public_read))
+
+    # def __repr__(self):
+    #     return (f'SampleACL[{self.owner}, {self.lastupdate}, {self.admin}, {self.write}, ' +
+    #             f'{self.read}, {self.public_read}]')


### PR DESCRIPTION
Currently if a user is in an admin ACL and read acls are requested for
that user, they will be demoted from admin. The DB layer now supports
the `at_least` toggle so that if users have at least the requested
permission their permissions are not altered.