### PR TITLE
Fix bugs in ACL updates with at_least = True 

### DIFF
--- a/test/arango_controller.py
+++ b/test/arango_controller.py
@@ -72,9 +72,9 @@ class ArangoController:
 
     def destroy(self, delete_temp_files: bool) -> None:
         """
-        Shut down the MongoDB server.
+        Shut down the ArangoDB server.
 
-        :param delete_temp_files: delete all the MongoDB data files and logs generated during the
+        :param delete_temp_files: delete all the ArangoDB data files and logs generated during the
             test.
         """
         if self._proc:

--- a/test/core/acls_test.py
+++ b/test/core/acls_test.py
@@ -191,21 +191,36 @@ def test_is_update():
     assert s.is_update(SampleACLDelta()) is False
 
     assert s.is_update(SampleACLDelta([u('a1')])) is False
+    assert s.is_update(SampleACLDelta([u('a1')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta([u('o')], at_least=True)) is False
     assert s.is_update(SampleACLDelta([u('a3')])) is True
 
     assert s.is_update(SampleACLDelta(write=[u('w2')])) is False
+    assert s.is_update(SampleACLDelta(write=[u('w2')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta(write=[u('o')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta(write=[u('a1')])) is True
+    assert s.is_update(SampleACLDelta(write=[u('a1')], at_least=True)) is False
     assert s.is_update(SampleACLDelta(write=[u('w4')])) is True
 
     assert s.is_update(SampleACLDelta(read=[u('r1')])) is False
+    assert s.is_update(SampleACLDelta(read=[u('r1')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta(read=[u('o')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta(read=[u('a1')])) is True
+    assert s.is_update(SampleACLDelta(read=[u('a1')], at_least=True)) is False
+    assert s.is_update(SampleACLDelta(read=[u('w1')])) is True
+    assert s.is_update(SampleACLDelta(read=[u('w1')], at_least=True)) is False
     assert s.is_update(SampleACLDelta(read=[u('r3')])) is True
 
     assert s.is_update(SampleACLDelta(remove=[u('a1')])) is True
+    assert s.is_update(SampleACLDelta(remove=[u('a1')], at_least=True)) is True
     assert s.is_update(SampleACLDelta(remove=[u('a3')])) is False
 
     assert s.is_update(SampleACLDelta(remove=[u('w2')])) is True
+    assert s.is_update(SampleACLDelta(remove=[u('w2')], at_least=True)) is True
     assert s.is_update(SampleACLDelta(remove=[u('w4')])) is False
 
     assert s.is_update(SampleACLDelta(remove=[u('r1')])) is True
+    assert s.is_update(SampleACLDelta(remove=[u('r1')], at_least=True)) is True
     assert s.is_update(SampleACLDelta(remove=[u('r3')])) is False
 
     assert s.is_update(SampleACLDelta(public_read=False)) is True
@@ -228,6 +243,9 @@ def test_is_update_fail():
         UnauthorizedError('ACLs for the sample owner u may not be modified by a delta update.'))
     _is_update_fail(
         s, SampleACLDelta([u('a')], remove=[u('v'), u('u')]),
+        UnauthorizedError('ACLs for the sample owner u may not be modified by a delta update.'))
+    _is_update_fail(
+        s, SampleACLDelta([u('a')], remove=[u('v'), u('u')], at_least=True),
         UnauthorizedError('ACLs for the sample owner u may not be modified by a delta update.'))
 
 

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -1240,6 +1240,54 @@ def _update_sample_acls(samplestorage, at_least):
         True)
 
 
+def test_update_sample_acls_with_at_least_True_and_owner_in_admin_acl(samplestorage):
+    # owner should be included in any changes with at_least = True.
+    _update_sample_acls_with_owner_in_acl(
+        samplestorage,
+        [UserID('foo'), UserID('bar1'), UserID('user')],
+        [UserID('baz1'), UserID('bat')],
+        [UserID('whoo1')],
+    )
+
+
+def test_update_sample_acls_with_at_least_True_and_owner_in_write_acl(samplestorage):
+    # owner should be included in any changes with at_least = True.
+    _update_sample_acls_with_owner_in_acl(
+        samplestorage,
+        [UserID('foo'), UserID('bar1')],
+        [UserID('baz1'), UserID('bat'), UserID('user')],
+        [UserID('whoo1')],
+    )
+
+
+def test_update_sample_acls_with_at_least_True_and_owner_in_read_acl(samplestorage):
+    # owner should be included in any changes with at_least = True.
+    _update_sample_acls_with_owner_in_acl(
+        samplestorage,
+        [UserID('foo'), UserID('bar1')],
+        [UserID('baz1'), UserID('bat')],
+        [UserID('whoo1'), UserID('user')],
+    )
+
+
+def _update_sample_acls_with_owner_in_acl(samplestorage, admin, write, read):
+    id_ = uuid.UUID('1234567890abcdef1234567890abcdef')
+    assert samplestorage.save_sample(
+        SavedSample(id_, UserID('user'), [TEST_NODE], dt(1), 'foo')) is True
+
+    samplestorage.update_sample_acls(
+        id_, SampleACLDelta(admin, write, read, public_read=True, at_least=True), dt(101))
+
+    res = samplestorage.get_sample_acls(id_)
+    assert res == SampleACL(
+        UserID('user'),
+        dt(101),
+        [UserID('foo'), UserID('bar1')],
+        [UserID('baz1'), UserID('bat')],
+        [UserID('whoo1')],
+        True)
+
+
 def test_update_sample_acls_noop_with_at_least_False(samplestorage):
     _update_sample_acls_noop(samplestorage, False)
 
@@ -1546,13 +1594,6 @@ def test_update_sample_acls_fail_alters_owner(samplestorage):
     _update_sample_acls_fail(samplestorage, id_, SampleACLDelta(write=[UserID('us')]), t, err)
     _update_sample_acls_fail(samplestorage, id_, SampleACLDelta(read=[UserID('us')]), t, err)
     _update_sample_acls_fail(samplestorage, id_, SampleACLDelta(remove=[UserID('us')]), t, err)
-
-    _update_sample_acls_fail(
-        samplestorage, id_, SampleACLDelta([UserID('us')], at_least=True), t, err)
-    _update_sample_acls_fail(
-        samplestorage, id_, SampleACLDelta(write=[UserID('us')], at_least=True), t, err)
-    _update_sample_acls_fail(
-        samplestorage, id_, SampleACLDelta(read=[UserID('us')], at_least=True), t, err)
     _update_sample_acls_fail(
         samplestorage, id_, SampleACLDelta(remove=[UserID('us')], at_least=True), t, err)
 


### PR DESCRIPTION
1) at_least didn't apply to the owner
2) at_least wasn't taken into account when determining whether an ACL update
  was a no-op.