### PR TITLE
Drop service wizard url as a parameter

### DIFF
--- a/.github/workflows/non_sdk_test.yml
+++ b/.github/workflows/non_sdk_test.yml
@@ -93,6 +93,10 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
+          echo "Create fake deployment config"
+          echo "[SampleService]" > service.cfg
+          echo "srv_wiz_url = https://ci.kbase.us/services/service_wizard" >> service.cfg
+          export KB_DEPLOYMENT_CONFIG=`pwd`/service.cfg
           pipenv install --dev
           pipenv run make test-sdkless
 

--- a/.github/workflows/non_sdk_test.yml
+++ b/.github/workflows/non_sdk_test.yml
@@ -31,7 +31,7 @@ jobs:
           MONGODB_VER: mongodb-linux-x86_64-3.6.16
           ARANGODB_VER: 3.5.1
           ARANGODB_V: 35
-          KAFKA_VER: 2.6.1
+          KAFKA_VER: 2.6.2
           SCALA_VER: 2.12
         run: |
           # upgrade and update

--- a/lib/SampleService/core/validator/builtin.py
+++ b/lib/SampleService/core/validator/builtin.py
@@ -358,7 +358,7 @@ def ontology_has_ancestor(d: Dict[str, Any]) -> Callable[[str, Dict[str, Primiti
     try:
         oac=OntologyAPI(srv_wizard_url)
         ret=oac.get_terms({"ids": [ancestor_term], "ns": ontology})
-        if len(ret["results"]) == 0:
+        if len(ret["results"]) == 0 or ret["results"][0]==None:
             raise ValueError(f"ancestor_term {ancestor_term} is not found in {ontology}")
     except Exception as err:
         if 'Parameter validation error' in str(err):

--- a/lib/SampleService/core/validator/builtin.py
+++ b/lib/SampleService/core/validator/builtin.py
@@ -23,6 +23,12 @@ from pint import DefinitionSyntaxError as _DefinitionSyntaxError
 from SampleService.core.core_types import PrimitiveType
 from installed_clients.OntologyAPIClient import OntologyAPI
 
+srv_wizard_url = None
+if 'KB_DEPLOYMENT_CONFIG' in os.environ:
+    with open(os.environ['KB_DEPLOYMENT_CONFIG']) as f:
+        for line in f:
+            if line.startswith('srv-wiz-url'):
+               srv_wizard_url = line.split('=')[1].strip()
 
 def _check_unknown_keys(d, expected):
     if type(d) != dict:
@@ -331,13 +337,10 @@ def ontology_has_ancestor(d: Dict[str, Any]) -> Callable[[str, Dict[str, Primiti
 
     The 'ancestor_term' parameter is required and must be a string. It is the ancestor name.
 
-    The 'srv_wiz_url' parameter is required and must be a string. It is kbase service wizard url for 
-    getting OntologyAPI service.
-
     :param d: the configuration map for the callable.
     :returns: a callable that validates metadata maps.
     '''
-    _check_unknown_keys(d, {'ontology', 'ancestor_term', 'srv_wiz_url'})
+    _check_unknown_keys(d, {'ontology', 'ancestor_term'})
 
     ontology = d.get('ontology')
     if not ontology:
@@ -351,15 +354,9 @@ def ontology_has_ancestor(d: Dict[str, Any]) -> Callable[[str, Dict[str, Primiti
     if type(ancestor_term) != str:
         raise ValueError('ancestor_term must be a string')
 
-    srv_wiz_url=d.get('srv_wiz_url')
-    if not srv_wiz_url:
-        raise ValueError('srv_wiz_url is a required paramter')
-    if type(srv_wiz_url) != str:
-        raise ValueError('srv_wiz_url must be a string')
-
     oac=None
     try:
-        oac=OntologyAPI(srv_wiz_url)
+        oac=OntologyAPI(srv_wizard_url)
         ret=oac.get_terms({"ids": [ancestor_term], "ns": ontology})
         if len(ret["results"]) == 0:
             raise ValueError(f"ancestor_term {ancestor_term} is not found in {ontology}")

--- a/test/core/validator/builtin_test.py
+++ b/test/core/validator/builtin_test.py
@@ -382,8 +382,7 @@ def _number_validate_fail(cfg, meta, expected):
 
 def test_ontology_has_ancestor():
   _ontology_has_ancestor_success(
-      {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483', 
-          'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+      {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483' },
       {'Material': 'ENVO:00002041', 'ENVO:Material': 'ENVO:00002006'})
 
 def _ontology_has_ancestor_success(cfg, meta):
@@ -401,19 +400,11 @@ def test_ontology_has_ancestor_build_fail():
         ValueError('ancestor_term is a required paramter'))
     _ontology_has_ancestor_build_fail({'ontology': 'foo', 'ancestor_term': ['foo']}, 
         ValueError('ancestor_term must be a string'))
-    _ontology_has_ancestor_build_fail({'ontology': 'foo', 'ancestor_term': 'bar', 'srv_wiz_url': None}, 
-        ValueError('srv_wiz_url is a required paramter'))
-    _ontology_has_ancestor_build_fail({'ontology': 'foo', 'ancestor_term': 'bar', 'srv_wiz_url': ['whoo']}, 
-        ValueError('srv_wiz_url must be a string'))
-    _ontology_has_ancestor_build_fail({'ontology': 'foo', 'ancestor_term': 'bar', 'srv_wiz_url': 'whoo'}, 
-        ValueError("whoo isn't a valid http url"))
     _ontology_has_ancestor_build_fail(
-        {'ontology': 'foo', 'ancestor_term':'ENVO:00010483', 
-            'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+        {'ontology': 'foo', 'ancestor_term':'ENVO:00010483'},
         ValueError('ontology foo doesn\'t exist'))
     _ontology_has_ancestor_build_fail(
-        {'ontology': 'envo_ontology', 'ancestor_term':'baz', 
-            'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+        {'ontology': 'envo_ontology', 'ancestor_term':'baz' },
         ValueError('ancestor_term baz is not found in envo_ontology'))
 
 def _ontology_has_ancestor_build_fail(cfg, expected):
@@ -423,16 +414,13 @@ def _ontology_has_ancestor_build_fail(cfg, expected):
 
 def test_ontology_has_ancestor_validate_fail():
     _ontology_has_ancestor_validate_fail(
-        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483', 
-            'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483' }, 
         {'a': None}, 'Metadata value at key a is None')
     _ontology_has_ancestor_validate_fail(
-        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483', 
-            'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00010483' }, 
         {'a': 'foo'}, 'Metadata value at key a does not have envo_ontology ancestor term ENVO:00010483')
     _ontology_has_ancestor_validate_fail(
-        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00002010', 
-            'srv_wiz_url':'https://ci.kbase.us/services/service_wizard'}, 
+        {'ontology': 'envo_ontology', 'ancestor_term':'ENVO:00002010' }, 
         {'a': 'ENVO:00002041'}, 'Metadata value at key a does not have envo_ontology ancestor term ENVO:00002010')
 
 def _ontology_has_ancestor_validate_fail(cfg, meta, expected):


### PR DESCRIPTION
The ontology validator requires a service wizard URL as a paramter.
That URL varies across deploys so it shouldn't be in the validator
config.  This changes it so that the URL is figured out through the
deploy config file.