### PR TITLE
Extend allowed data in key_metadata

### DIFF
--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -165,7 +165,7 @@ _META_VAL_JSONSCHEMA = {
                     'key_metadata': {
                         'type': 'object',
                         'additionalProperties': {
-                            'type': ['number', 'boolean', 'string', 'null']
+                            'type': ['array', 'object', 'number', 'boolean', 'string', 'null']
                         }
                     },
                     'validators': {

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -218,11 +218,6 @@ def _config_get_validators_fail_bad_params(temp_dir, key_):
                         'key_metadata': []}}},
         temp_dir, ValidationError("[] is not of type 'object'"))
     _config_get_validators_fail(
-        {key_: {'key': {'validators': [{'module': 'foo',
-                                        'callable_builder': 'bar'}],
-                        'key_metadata': {'a': {}}}}},
-        temp_dir, ValidationError("{} is not of type 'number', 'boolean', 'string', 'null'"))
-    _config_get_validators_fail(
         {key_: {'key': {'validators': [{}]}}}, temp_dir,
         ValidationError("'module' is a required property"))
     _config_get_validators_fail(


### PR DESCRIPTION
We would like to start packing more information into the key_metadata
including nested structures.  So let's relax this check.  We may
want to add some constraints later once we know what we need.