### PR TITLE
Make core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/test.cfg
 test_local
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,23 @@
-FROM kbase/sdkbase2:python
+FROM python:3.7
 MAINTAINER KBase Developer
 # -----------------------------------------
-# In this section, you can install any system dependencies required
-# to run your App.  For instance, you could place an apt-get update or
-# install line here, a git checkout to download code, or run any other
-# installation scripts.
 
-# RUN apt-get update
+ENV DOCKERIZE_VERSION v0.6.1
 
-RUN lsb_release -a
+RUN \
+    curl -o dockerize.tar.gz \
+    https://raw.githubusercontent.com/kbase/dockerize/master/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xvzf dockerize.tar.gz && \
+    rm dockerize.tar.gz
 
-# deactivate &**&)^&&*_)&ing conda
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN echo $PATH
-RUN rm -r /miniconda
-
-# install python 3.7
-RUN sudo apt-get update
-RUN sudo apt-get install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
-    libssl-dev libreadline-dev libffi-dev curl libbz2-dev libsqlite3-dev -y
-RUN cd /opt \
-    && curl -O https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz \
-    && tar -xf Python-3.7.3.tar.xz \
-    && cd Python-3.7.3 \
-    && ./configure --enable-optimizations --with-ensurepip=install \
-        --enable-loadable-sqlite-extensions\
-    && make -j 8 \
-    && make install
-
-RUN rm /opt/Python-3.7.3.tar.xz \
-    && rm -r /opt/Python-3.7.3
-
-RUN ln -s /usr/local/bin/python3.7 /usr/local/bin/python
-RUN ln -s /usr/local/bin/pip3 /usr/local/bin/pip
-RUN which python
-RUN python --version
-
-# install arango for tests. Kind of pointless until the other deps are also installed
-ENV ARANGO_VER=3.5.1
-ENV ARANGO_VER_PRE=35
-
-RUN curl -O https://download.arangodb.com/arangodb$ARANGO_VER_PRE/Community/Linux/arangodb3-linux-$ARANGO_VER.tar.gz \
-    && tar -xf arangodb3-linux-$ARANGO_VER.tar.gz 
-
-ENV ARANGO_EXE=/arangodb3-$ARANGO_VER/usr/sbin/arangod
-ENV ARANGO_JS=/arangodb3-$ARANGO_VER/usr/share/arangodb3/js/
 
 RUN pip install pipenv
 
 # -----------------------------------------
+COPY Pipfile /tmp/Pipfile
+COPY Pipfile.lock /tmp/Pipfile.lock
+RUN cd /tmp && pipenv install --system --deploy --ignore-pipfile --dev
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
@@ -57,16 +26,7 @@ RUN chmod -R a+rw /kb/module
 WORKDIR /kb/module
 
 # really need a test build and a prod build. Not sure that's possible via sdk.
-RUN pipenv install --system --deploy --ignore-pipfile --dev
-
-RUN cd test \
-    && cp test.cfg.example test-sdk.cfg \
-    && sed -i "s#^test.temp.dir=.*#test.temp.dir=temp_test_dir#" test-sdk.cfg \
-    && sed -i "s#^test.arango.exe.*#test.arango.exe=$ARANGO_EXE#" test-sdk.cfg \
-    && sed -i "s#^test.arango.js.*#test.arango.js=$ARANGO_JS#" test-sdk.cfg \
-    && cat test-sdk.cfg
-
-RUN make all
+# RUN pipenv install --system --deploy --ignore-pipfile --dev
 
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,8 @@ LIB_DIR = lib
 SCRIPTS_DIR = scripts
 TEST_DIR = test
 TEST_CONFIG_FILE = test.cfg
-TEST_CONFIG_FILE_SDK = test-sdk.cfg
 LBIN_DIR = bin
 WORK_DIR = /kb/module/work/tmp
-EXECUTABLE_SCRIPT_NAME = run_$(SERVICE_CAPS)_async_job.sh
-STARTUP_SCRIPT_NAME = start_server.sh
-TEST_SCRIPT_NAME = run_tests.sh
 # see https://stackoverflow.com/a/23324703/643675
 MAKEFILE_DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 
@@ -18,7 +14,6 @@ TEST_SPEC := $(TEST_DIR)
 
 PYPATH=$(MAKEFILE_DIR)/$(LIB_DIR):$(MAKEFILE_DIR)/$(TEST_DIR)
 TSTFL=$(MAKEFILE_DIR)/$(TEST_DIR)/$(TEST_CONFIG_FILE)
-TSTFL_SDK=$(MAKEFILE_DIR)/$(TEST_DIR)/$(TEST_CONFIG_FILE_SDK)
 
 .PHONY: test
 
@@ -43,46 +38,8 @@ compile:
 		--out . \
 		--html \
 
-build:
-	chmod +x $(SCRIPTS_DIR)/entrypoint.sh
-
-build-executable-script:
-	mkdir -p $(LBIN_DIR)
-	echo '#!/bin/bash' > $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-	echo 'python -u $$script_dir/../$(LIB_DIR)/$(SERVICE_CAPS)/$(SERVICE_CAPS)Server.py $$1 $$2 $$3' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-	chmod +x $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-
-build-startup-script:
-	mkdir -p $(LBIN_DIR)
-	echo '#!/bin/bash' > $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	echo 'export KB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	echo 'gunicorn --worker-class gevent --timeout 30 --workers 17 --bind :5000 --log-level info $(SERVICE_CAPS).$(SERVICE_CAPS)Server:application' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	chmod +x $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-
-build-test-script:
-	echo '#!/bin/bash' > $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'lib=$$script_dir/../$(LIB_DIR)/$(SERVICE_CAPS)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'export KB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'export KB_AUTH_TOKEN=`cat /kb/module/work/token`' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'echo "Removing temp files..."' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'rm -rf $(WORK_DIR)/*' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'echo "...done removing temp files."' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'SAMPLESERV_TEST_FILE=$(TSTFL_SDK) pytest  --verbose --cov=$$lib --cov-config=coveragerc --cov-report=html .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'mv .coverage /kb/module/work/' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'rm -r /kb/module/work/test_coverage' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'mv htmlcov /kb/module/work/test_coverage' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	chmod +x $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-
 test:
-	if [ ! -f /kb/module/work/token ]; then echo -e '\nOutside a docker container please run "kb-sdk test" rather than "make test"\n' && exit 1; fi
-	bash $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo Use test-sdkless
 
 test-sdkless:
 # TODO flake8 and bandit

--- a/deploy.cfg.tmpl
+++ b/deploy.cfg.tmpl
@@ -1,0 +1,79 @@
+[SampleService]
+kbase-endpoint = {{ default .Env.kbase_endpoint "https://ci.kbase.us/services/" }}
+workspace-url = {{ default .Env.workspace_url "https://ci.kbase.us/services/ws" }}
+srv-wiz-url = {{ default .Env.srv_wiz_url "https://ci.kbase.us/services/service_wizard" }}
+auth-service-url = {{ default .Env.auth_service_url "https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login" }}
+auth-service-url-allow-insecure = {{ default .Env.auth_service_url_allow_insecure "false" }}
+scratch = /kb/module/work/tmp
+
+# Location and credentials for the KBase Authentication service.
+# auth-root-url is the KBase auth service root url, e.g. https://kbase.us/services/auth
+# auth-token is any valid auth token for the sample service to use for user lookups. A service
+# token is recommended.
+# auth-full-admin-roles is a comma separated list of authentication service custom roles that
+# denote a user is a full admin of the sample service.
+# auth-full-admin-roles is a comma separated list of authentication service custom roles that
+# denote a user has admin read privileges for the sample service.
+
+auth-root-url = {{ default .Env.auth_root_url "https://ci.kbase.us/services/auth" }}
+auth-token = {{ default .Env.auth_token "" }}
+
+auth-full-admin-roles = {{ default .Env.auth_full_admin_roles "SAMPLE_SERVICE_FULL_ADMIN" }}
+auth-read-admin-roles = {{ default .Env.auth_read_admin_roles "SAMPLE_SERVICE_READ_ADMIN" }}
+
+# Credentials for the KBase workspace service. The token must have read
+# administration permissions.
+
+workspace-read-admin-token={{ default .Env.workspace_read_admin_token "" }}
+
+# Location and credentials for the ArangoDB instance in which to store data.
+# The DB is expected to be shared with the KBase relation engine.
+
+arango-url = {{ default .Env.arango_url "" }}
+arango-db = {{ default .Env.arango_db "" }}
+arango-user = {{ default .Env.arango_user ""}}
+arango-pwd = {{ default .Env.arango_pwd ""}}
+
+# Collection names for the sample service to use. These are configurable because:
+# 1) The collection names might collide with Relation Engine collection names if hard coded into
+#    the service as per normal practice
+# 2) The service should not create collections on start up to allow for admins to do so instead,
+#    so the admins can set up sharding correctly, which cannot be changed after collection
+#    creation.
+
+# The workspace object shadow collection should be the collection the KBase Relation Engine
+# uses for its workspace object version documents. The Sample Server does not write to this
+# collection.
+
+#    ---- Collection descriptions ----
+# sample-collection = "sample id and acls"
+# version-collection = "name, version, version uuid (transaction key), and some other stuff"
+# version-edge-collection = "links samples with version"
+# node-collection = "all the nodes we talked about. metadata fields stored here"
+# node-edge-collection = "edges between versions and nodes"
+# data-link-collection = "link between nodes and workspace objects."
+# workspace-object-version-shadow-collection = "RE workspace shadow collection"
+# schema-collection = "1 object that says "this is the database schema version". for service start up"
+
+sample-collection = {{ default .Env.sample_collection "samples_sample" }}
+version-collection = {{ default .Env.version_collection "samples_version" }}
+version-edge-collection = {{ default .Env.version_edge_collection "samples_ver_edge" }}
+node-collection = {{ default .Env.node_collection "samples_nodes" }}
+node-edge-collection = {{ default .Env.node_edge_collection "samples_nodes_edge" }}
+data-link-collection = {{ default .Env.data_link_collection "samples_data_link" }}
+workspace-object-version-shadow-collection = {{ default .Env.workspace_object_version_shadow_collection "ws_object_version" }}
+schema-collection = {{ default .Env.schema_collection "samples_schema" }}
+
+# A URL pointing to a configuration file for any metadata validators to be installed on startup.
+# See the readme file for a description of the file contents.
+metadata-validator-config-url = {{ default .Env.metadata_validator_config_url "https://raw.githubusercontent.com/kbase/sample_service_validator_config/master/metadata_validation.yml" }}
+
+# Parameters for Kafka notifications.
+#
+# kafka-bootstrap-servers is equivalent to the Kafka bootstrap.servers parameter. Leave blank to
+# disable the Kafka notifier.
+#
+# kafka-topic is the topic to which the Kafka notifier should write. Required if
+# kafka-bootstrap-servers is provided. Legal characters are alphanumerics and the hyphen.
+kafka-bootstrap-servers = {{ default .Env.kafka_bootstrap_servers "" }}
+kafka-topic = {{ default .Env.kafka_topic "" }}

--- a/scripts/run_async.sh
+++ b/scripts/run_async.sh
@@ -1,9 +1,0 @@
-script_dir=$(dirname "$(readlink -f "$0")")
-export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
-WD=/kb/module/work
-if [ -f $WD/token ]; then
-    cat $WD/token | xargs sh $script_dir/../bin/run_SampleService_async_job.sh $WD/input.json $WD/output.json
-else
-    echo "File $WD/token doesn't exist, aborting."
-    exit 1
-fi


### PR DESCRIPTION
This switches the sample service to be more in line with other core services...
* Simplified Dockerfile that results in a shorter build time and smaller image
* Drop docker-ized kb-sdk test model entirely since it didn't work anyway
* Change entrypoint startup to use dockerize