### PR TITLE
Add clearer error messages for malformed or missing sample ids in get…

### DIFF
--- a/lib/SampleService/SampleServiceImpl.py
+++ b/lib/SampleService/SampleServiceImpl.py
@@ -404,8 +404,18 @@ Note that usage of the administration flags will be logged by the service.
         # ctx is the context object
         # return variables are: samples
         #BEGIN get_samples
-        if not params.get('samples'):
-          raise ValueError(f"")
+        # if not params.get('samples'):
+        #   raise ValueError(f"")
+        if type(params.get('samples')) is not list:
+            raise ValueError(
+                'Missing or incorrect "samples" field - ' +
+                'must provide a list of samples to retrieve.'
+            )
+        if len(params.get('samples')) == 0:
+            raise ValueError(
+                'Cannot provide empty list of samples - ' +
+                'must provide at least one sample to retrieve.'
+            )
         ids_ = []
         for samp_obj in params['samples']:
           id_, ver = _get_sample_address_from_object(samp_obj)

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -880,6 +880,21 @@ def _create_sample_version_as_admin(sample_port, as_user, expected_user):
     }
 
 
+def test_get_samples_fail_no_samples(sample_port):
+    _test_get_samples_fail(sample_port, None,
+        'Missing or incorrect "samples" field - must provide a list of samples to retrieve.')
+
+    _test_get_samples_fail(sample_port, "im a random sample id string!",
+        'Missing or incorrect "samples" field - must provide a list of samples to retrieve.')
+
+    _test_get_samples_fail(sample_port, [],
+        'Cannot provide empty list of samples - must provide at least one sample to retrieve.')
+
+
+def _test_get_samples_fail(sample_port, samples, message):
+    params = {'samples': samples}
+    _request_fail(sample_port, 'get_samples', TOKEN1, params, message)
+
 def test_get_sample_public_read(sample_port):
     url = f'http://localhost:{sample_port}'
     id_ = _create_generic_sample(url, TOKEN1)


### PR DESCRIPTION
…_samples