### PR TITLE
SAM-151: Optimize get bulk data links

### DIFF
--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -169,7 +169,6 @@ class Samples:
             for i, level in enumerate(levels):
                 if level < access:
                     uerr = f'User {user}' if user else 'Anonymous users'
-                    # TODO: will ids_[i] actually match up with the right sample that's missing?
                     errmsg = f'{uerr} {self._unauth_errmap[access]} sample {ids_[i]}'
                     raise _UnauthorizedError(errmsg)
 

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -154,6 +154,25 @@ class Samples:
                       _SampleAccessType.WRITE: 'cannot write to',
                       _SampleAccessType.READ: 'cannot read'}
 
+    def _check_batch_perms(
+        self,
+        ids_: List[UUID],
+        user: Optional[UserID],
+        access: _SampleAccessType,
+        acls: List[SampleACL] = None,
+        as_admin: bool = False):
+            if as_admin:
+                return
+            if not acls:
+                acls = self._storage.get_sample_set_acls(ids_)
+            levels = [self._get_access_level(acl, user) for acl in acls]
+            for i, level in enumerate(levels):
+                if level < access:
+                    uerr = f'User {user}' if user else 'Anonymous users'
+                    # TODO: will ids_[i] actually match up with the right sample that's missing?
+                    errmsg = f'{uerr} {self._unauth_errmap[access]} sample {ids_[i]}'
+                    raise _UnauthorizedError(errmsg)
+
     def _get_access_level(self, acls: SampleACL, user: Optional[UserID]):
         if user == acls.owner:
             return _SampleAccessType.OWNER
@@ -465,17 +484,11 @@ class Samples:
         '''
         _not_falsy(samples, 'samples')
         timestamp = self._resolve_timestamp(timestamp)
-
         wsids = None if as_admin else self._ws.get_user_workspaces(user)
-        # TODO DATALINK what about deleted objects? Currently not handled
-        return_links = []
-        for sample in samples:
-            # TODO: consider adding support for sample set refs, so that we don't have to check
-            # perms for every individual sample. It does not appear to create a significant
-            # bottleneck as implemented but it could help with a lot of samples at once
-            self._check_perms(sample.sampleid, user, _SampleAccessType.READ, as_admin=as_admin)
-            return_links.extend(self._storage.get_links_from_sample(sample, wsids, timestamp))
-
+        # checks for all sample acls in one query
+        sampleids = [s.sampleid for s in samples]
+        self._check_batch_perms(sampleids, user, _SampleAccessType.READ, as_admin=as_admin)
+        return_links = self._storage.get_batch_links_from_samples(samples, wsids, timestamp)
         return return_links, timestamp
 
     def _resolve_timestamp(self, timestamp: datetime.datetime = None) -> datetime.datetime:

--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -849,6 +849,23 @@ class ArangoSampleStorage:
             # allow None for backwards compability with DB entries missing the key
             acls.get(_FLD_PUBLIC_READ))
 
+    def get_sample_set_acls(self, ids_: List[UUID]) -> List[SampleACL]:
+        # have to cast this way for compatibility with _get_many_sample_doc
+        docs = self._get_many_sample_doc([{'id': _cast(str, id_)} for id_ in ids_])
+        sample_acls = []
+        for doc in docs:
+            acls = doc[_FLD_ACLS]
+            sample_acls.append(SampleACL(
+                UserID(acls[_FLD_OWNER]),
+                self._timestamp_to_datetime(doc[_FLD_ACL_UPDATE_TIME]),
+                [UserID(u) for u in acls[_FLD_ADMIN]],
+                [UserID(u) for u in acls[_FLD_WRITE]],
+                [UserID(u) for u in acls[_FLD_READ]],
+                acls.get(_FLD_PUBLIC_READ)
+            ))
+
+        return sample_acls
+
     def replace_sample_acls(self, id_: UUID, acls: SampleACL):
         '''
         Completely replace a sample's ACLs.
@@ -1481,6 +1498,68 @@ class ArangoSampleStorage:
         except _arango.exceptions.AQLQueryExecuteError as e:  # this is a pain to test
             raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
         return duids  # a maxium of 10k can be returned based on the link creation function
+
+    def get_batch_links_from_samples(self,
+                                     samples: List[SampleAddress],
+                                     readable_wsids: Optional[List[int]],
+                                     timestamp: datetime.datetime) -> List[DataLink]:
+        '''
+        Get the links from a bulk list of samples at a particular time.
+
+        :param samples: the samples of interest.
+        :param readable_wsids: IDs of workspaces for which the user has read permissions.
+            Pass None to return links to objects in all workspaces.
+        :param timestamp: the time to use to determine which links are active.
+        :returns: a list of links.
+        :raises SampleStorageError: if a conection to the database fails.
+        '''
+
+        _not_falsy(samples, 'samples')
+        _check_timestamp(timestamp, 'timestamp')
+
+        aql_bind = {
+            '@sample_col': self._col_sample.name,
+            '@link_col': self._col_data_link.name,
+            # cast SampleAddress to dict
+            'sample_ids': [{'id': str(s.sampleid), 'version': s.version} for s in samples],
+            'ts': self._timestamp_seconds_to_milliseconds(timestamp.timestamp())
+        }
+
+        wsidfilter = ''
+        if readable_wsids:
+            aql_bind['wsids'] = readable_wsids
+            wsidfilter = f'FILTER d.{_FLD_LINK_WORKSPACE_ID} IN @wsids'
+
+        q = f'''
+            LET version_ids = (FOR sample_id IN @sample_ids
+                LET doc = DOCUMENT(@@sample_col, sample_id.id)
+                RETURN {{
+                    'id': doc.id,
+                    'version_id': doc.vers[sample_id.version - 1],
+                    'version': sample_id.version
+                }}
+            )
+
+            LET data_links = (FOR version_id IN version_ids
+                FOR d in @@link_col
+                    FILTER d.{_FLD_LINK_SAMPLE_UUID_VERSION} == version_id.version_id
+                    {wsidfilter}
+                    FILTER d.{_FLD_LINK_CREATED} <= @ts
+                    FILTER d.{_FLD_LINK_EXPIRED} >= @ts
+                    RETURN d
+            )
+            RETURN data_links
+        '''
+
+        duids = []
+        try:
+            # have to unwrap query result twice because its a nested array
+            for link_set in self._db.aql.execute(q, bind_vars=aql_bind):
+                for link in link_set:
+                    duids.append(self._doc_to_link(link))
+        except _arango.exceptions.AQLQueryExecuteError as e:
+            raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
+        return duids
 
     def get_links_from_data(self, upa: UPA, timestamp: datetime.datetime) -> List[DataLink]:
         '''

--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -850,8 +850,14 @@ class ArangoSampleStorage:
             acls.get(_FLD_PUBLIC_READ))
 
     def get_sample_set_acls(self, ids_: List[UUID]) -> List[SampleACL]:
+        # function to ensure docs are sorted correctly
+        str_ids = [str(id_) for id_ in ids_]
+        def _keyfunc(doc):
+            return str_ids.index(doc[_FLD_ARANGO_KEY])
         # have to cast this way for compatibility with _get_many_sample_doc
-        docs = self._get_many_sample_doc([{'id': _cast(str, id_)} for id_ in ids_])
+        docs = self._get_many_sample_doc([{'id': str_id} for str_id in str_ids])
+        # sort docs (ensure that the right id is raised for errors)
+        sorted_docs = sorted(docs, key=_keyfunc)
         sample_acls = []
         for doc in docs:
             acls = doc[_FLD_ACLS]

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -3314,7 +3314,8 @@ def test_get_links_from_sample_set_fail(sample_port):
             'sample_ids': [{'id': str(badid), 'version': 1}],
             'effective_time': _get_current_epochmillis() - 500
         },
-        f'Sample service error code 50010 No such sample: {badid}')
+        'Sample service error code 50010 No such sample:' +
+        f" Could not complete search for samples: ['{badid}']")
 
     # admin tests
     _get_links_from_sample_set_fail(

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -3314,7 +3314,7 @@ def test_get_links_from_sample_set_fail(sample_port):
             'sample_ids': [{'id': str(badid), 'version': 1}],
             'effective_time': _get_current_epochmillis() - 500
         },
-        'Sample service error code 50010 No such sample:' +
+        'Sample service error code 50010 No such sample:'
         f" Could not complete search for samples: ['{badid}']")
 
     # admin tests


### PR DESCRIPTION
* Creates new arango method that will grab all linked data types in one query rather than one per sample
* Also  Handles ACL checks for `get_data_links_from_sample_set` in bulk so that they are all checked using only one AQL query
* Performance improvements from running local tests appear to be about ~15x faster than several singular calls