### PR TITLE
SAM-198 Fix update_sample_acls to prevent erronious errors

### DIFF
--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -1027,7 +1027,7 @@ class ArangoSampleStorage:
         aql += '''
                         }
                     } IN @@col
-                RETURN s
+                RETURN NEW
             '''
 
         try:

--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -901,7 +901,7 @@ class ArangoSampleStorage:
                 UPDATE s WITH {{{_FLD_ACLS}: MERGE(s.{_FLD_ACLS}, @acls),
                                 {_FLD_ACL_UPDATE_TIME}: @ts
                                 }} IN @@col
-                RETURN s
+                RETURN NEW
             '''
         bind_vars = {'@col': self._col_sample.name,
                      'id': str(id_),


### PR DESCRIPTION
Fixes `update_sample_acls` to prevent erroneous "owner unexpectedly changed" errors from being thrown due to a bad count of changed documents.